### PR TITLE
Fix: [기능] #19 일정 저장 기능 구현

### DIFF
--- a/app/data_models/data_model.py
+++ b/app/data_models/data_model.py
@@ -61,7 +61,7 @@ class Plan(SQLModel, table=True):
     end_date: Optional[datetime] = None
     main_location: Optional[str] = Field(default=None, max_length=50)
     ages: Optional[int] = None
-    companion_count: Optional[int] = None
+    companion_count: Optional[str] = None
     concepts: Optional[str] = Field(default=None, max_length=255)
     member_id: int = Field(foreign_key="member.id")
     created_at: Optional[datetime] = None

--- a/app/repository/db.py
+++ b/app/repository/db.py
@@ -43,14 +43,12 @@ def get_session_sync():
     finally:
         print("세션을 종료합니다.")
         session.close()
-            
-def drop_table_by_SQLModel():
-    print("테이블을 삭제합니다.")
-    print("테이블 삭제 완료")
 
 def init_table_by_SQLModel(): 
     with engine.connect() as connection:
+        print("테이블을 삭제합니다.")
         SQLModel.metadata.drop_all(connection)
+        print("테이블 삭제 완료")
         print("테이블을 생성합니다.")
         SQLModel.metadata.create_all(connection)
         print("테이블 생성 완료")

--- a/app/repository/members/mebmer_repository.py
+++ b/app/repository/members/mebmer_repository.py
@@ -19,6 +19,14 @@ def get_member_by_id(member_id: int, session:Session) -> Member:
     except Exception as e:
         print("[ memberRepository ] get_member_by_id() 에러 : ", e)
 
+def get_memberId_by_email(email: str, session:Session) -> Member:
+    try:
+        query = select(Member).where((Member.email == email))
+        member = session.exec(query).first()
+        return member.id if member is not None else None
+    except Exception as e:
+        print("[ memberRepository ] get_memberId_by_email() 에러 : ", e)
+
 def is_exist_member_by_email(email: str, oauth: str, session:Session) -> bool:
     try:
         print("session type : ", type(session))

--- a/app/repository/plans/plan_repository.py
+++ b/app/repository/plans/plan_repository.py
@@ -1,10 +1,17 @@
 from fastapi import Depends
 from sqlmodel import Session
 from app.data_models.data_model import Plan
+from datetime import datetime
 
 # plan을 저장하고 id를 반환함. (CQS 고려하지 않음.)
 def save_plan(plan: Plan, session: Session):
     try:
+        # ISO 형식의 문자열을 datetime 객체로 변환 후 MySQL 형식으로 변환
+        start_date = datetime.fromisoformat(plan.start_date.replace('Z', '+00:00'))
+        end_date = datetime.fromisoformat(plan.end_date.replace('Z', '+00:00'))
+        
+        plan.start_date = start_date
+        plan.end_date = end_date
         session.add(plan)
         session.flush()
         print("[ plan_repository ] new_plan.id : ", plan.id)

--- a/app/services/plans/plan_service.py
+++ b/app/services/plans/plan_service.py
@@ -3,9 +3,10 @@ from app.repository.plans.plan_repository import get_plan, save_plan
 from sqlmodel import Session
 
 def reg_plan(plan: Plan, member_id: int, session: Session):
+    print("[ plan_service ] member_id : ", member_id)  # 디버깅용
     plan.member_id = member_id
+    print("[ plan_service ] plan.member_id : ", plan.member_id)  # 디버깅용
     plan_id = save_plan(plan, session)
-
     return plan_id
 
 def find_plan(plan_id: int, session: Session):


### PR DESCRIPTION
## 출력된 일정의 저장 기능을 구현했습니다.
### 진행 / 수정 사항
1. `companion_count` 컬럼의 타입을 `int` 에서 `str`로 변경
2. 추가 테이블을 생성하지 않기 위해 프론트에서 위의 컬럼에 해당하는 해당 리스트를 문자열로 파싱한후 전송합니다.
3.  `get_memberId_by_email` 추가. 현재 프론트에서 저장하고 있는 그나마 유니크한 회원 정보가 email이라서, 이를 전송하고 save하도록 했습니다.
4. HttpOnly 쿠키는 HTTPS환경에서 제대로 사용할 수 있기 때문에 3.은 임시방편입니다. HTTPS를 도입하더라도 jwt생성시 memberId를 담을지는 또 고민해야할 부분인 것 같습니다.
5. 프론트가 전송하는 날짜 타입을 MySQL이 이해할 수 있는 iso표준으로 변경 후 저장하도록 했습니다.

### 필요한 진행사항
- 프론트의 user상태에 어떤 oauth로 접속한상태인지 구별 필요 (똑같은 이메일이더라도 다른 oauth일 수 있음)
