### PR TITLE
[기능] 일정 수정 로직 추가

### DIFF
--- a/app/data_models/data_model.py
+++ b/app/data_models/data_model.py
@@ -68,8 +68,8 @@ class Plan(SQLModel, table=True):
     updated_at: Optional[datetime] = None
     
     member: Member = Relationship(back_populates="plans")
-    checklist: Optional["Checklist"] = Relationship(back_populates="plan", cascade="all, delete-orphan")
-    plan_spots: List["PlanSpotMap"] = Relationship(back_populates="plan", cascade="all, delete-orphan")
+    checklist: Optional["Checklist"] = Relationship(back_populates="plan", cascade_delete=True)
+    plan_spots: List["PlanSpotMap"] = Relationship(back_populates="plan", cascade_delete=True)
 
 class Spot(SQLModel, table=True):
     __tablename__ = "spot"
@@ -94,8 +94,10 @@ class Spot(SQLModel, table=True):
         sa_column_kwargs={"server_default": text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"), "nullable": False}
     )
     
-    plan_spots: List["PlanSpotMap"] = Relationship(back_populates="spot", cascade="all, delete-orphan")
+    plan_spots: List["PlanSpotMap"] = Relationship(back_populates="spot", cascade_delete=True)
     spot_tags: List["PlanSpotTagMap"] = Relationship(back_populates="spot")
+
+
 
     @validator("business_status", pre=True, always=True)
     def convert_bool_to_int(cls, value):

--- a/app/data_models/data_model.py
+++ b/app/data_models/data_model.py
@@ -68,8 +68,8 @@ class Plan(SQLModel, table=True):
     updated_at: Optional[datetime] = None
     
     member: Member = Relationship(back_populates="plans")
-    checklist: Optional["Checklist"] = Relationship(back_populates="plan")
-    plan_spots: List["PlanSpotMap"] = Relationship(back_populates="plan")
+    checklist: Optional["Checklist"] = Relationship(back_populates="plan", cascade="all, delete-orphan")
+    plan_spots: List["PlanSpotMap"] = Relationship(back_populates="plan", cascade="all, delete-orphan")
 
 class Spot(SQLModel, table=True):
     __tablename__ = "spot"
@@ -94,7 +94,7 @@ class Spot(SQLModel, table=True):
         sa_column_kwargs={"server_default": text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"), "nullable": False}
     )
     
-    plan_spots: List["PlanSpotMap"] = Relationship(back_populates="spot")
+    plan_spots: List["PlanSpotMap"] = Relationship(back_populates="spot", cascade="all, delete-orphan")
     spot_tags: List["PlanSpotTagMap"] = Relationship(back_populates="spot")
 
     @validator("business_status", pre=True, always=True)

--- a/app/repository/db.py
+++ b/app/repository/db.py
@@ -44,6 +44,7 @@ def get_session_sync():
         print(f"💡[ 세션 생성 ] {filename} - {function_name}")
 
         yield session
+        session.commit()
     except Exception as e:
         logging.debug(f"💡logger: 데이터 베이스 예외 발생: {e}")
         session.rollback()

--- a/app/repository/db.py
+++ b/app/repository/db.py
@@ -1,6 +1,8 @@
 from contextlib import asynccontextmanager
 import logging
 import os
+import inspect
+import traceback
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from sqlalchemy import create_engine, text
@@ -36,14 +38,19 @@ async def lifespan(app: FastAPI):
 def get_session_sync():
     session = SessionLocal()
     try:
-        print("세션을 생성합니다.")
+        frame = inspect.stack()[2]
+        filename = frame.filename
+        function_name = frame.function
+        print(f"💡[ 세션 생성 ] {filename} - {function_name}")
+
         yield session
     except Exception as e:
         logging.debug(f"💡logger: 데이터 베이스 예외 발생: {e}")
         session.rollback()
         raise RuntimeError("데이터베이스 연결 실패") from e
     finally:
-        print("세션을 종료합니다.")
+        print(f"💡[ 세션 종료 ] {filename} - {function_name}")
+
         session.close()
 
 def init_table_by_SQLModel(): 

--- a/app/repository/db.py
+++ b/app/repository/db.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+import logging
 import os
 from dotenv import load_dotenv
 from fastapi import FastAPI
@@ -38,7 +39,8 @@ def get_session_sync():
         print("세션을 생성합니다.")
         yield session
     except Exception as e:
-        print(f"[Error] 세션 생성 중 예외 발생: {e}")
+        logging.debug(f"💡logger: 데이터 베이스 예외 발생: {e}")
+        session.rollback()
         raise RuntimeError("데이터베이스 연결 실패") from e
     finally:
         print("세션을 종료합니다.")

--- a/app/repository/members/mebmer_repository.py
+++ b/app/repository/members/mebmer_repository.py
@@ -6,7 +6,6 @@ from app.data_models.data_model import Member
 def save_member(member: Member, session:Session) -> int:
     try:
         session.add(member)
-        session.commit()
         return member.id
     except Exception as e:
         print("[ memberRepository ] save_member() 에러 : ", e)

--- a/app/repository/plans/plan_repository.py
+++ b/app/repository/plans/plan_repository.py
@@ -74,4 +74,18 @@ def get_member_plans(member_id: int, session: Session):
         print("[ plan_repository ] get_member_plans() 에러 : ", e)
         raise e
 
+async def delete_plan(plan_id: int, session: Session):
+    try:
+        plan = session.get(Plan, plan_id)
+        if plan is None:
+            raise ValueError(f"ID가 {plan_id}인 Plan을 찾을 수 없습니다.")
+        session.delete(plan)
+        session.commit()
+        return True
+    except Exception as e:
+        print("[ plan_repository ] delete_plan() 에러 : ", e)
+        raise e
+
+
+
    

--- a/app/repository/plans/plan_repository.py
+++ b/app/repository/plans/plan_repository.py
@@ -40,7 +40,6 @@ def save_plan(plan: Plan, session: Session, plan_id: int = None):
             plan_id = plan.id
             print("[ plan_repository ] 새로운 plan 생성 완료 : ", plan_id)
             
-        session.commit()
         return plan_id
     except Exception as e:
         print("[ plan_repository ] save_plan() 에러 : ", e)
@@ -50,7 +49,6 @@ def save_plan(plan: Plan, session: Session, plan_id: int = None):
 def get_plan(plan_id: int, session: Session):
     try:
         plan = session.get(Plan, plan_id)
-        session.commit()
         return plan if plan is not None else None
 
     except Exception as e:
@@ -73,7 +71,6 @@ def get_member_plans(member_id: int, session: Session):
         
         print("[ plan_repository ] get_member_plans() 결과 : ", plans)
         print("[ plan_repository ] get_member_plans() 결과 타입 : ", type(plans))
-        session.commit()
         return plans
     except Exception as e:
         print("[ plan_repository ] get_member_plans() 에러 : ", e)
@@ -85,7 +82,6 @@ def delete_plan(plan_id: int, session: Session):
         if plan is None:
             raise ValueError(f"ID가 {plan_id}인 Plan을 찾을 수 없습니다.")
         session.delete(plan)
-        session.commit()
         return True
     except Exception as e:
         print("[ plan_repository ] delete_plan() 에러 : ", e)

--- a/app/repository/plans/plan_repository.py
+++ b/app/repository/plans/plan_repository.py
@@ -8,6 +8,7 @@ from app.utils import serialize_time
 # plan을 저장하거나 수정하고 id를 반환함. (CQS 고려하지 않음.)
 def save_plan(plan: Plan, session: Session, plan_id: int = None):
     try:
+
         # ISO 형식의 문자열을 datetime 객체로 변환 후 MySQL 형식으로 변환
         start_date = datetime.fromisoformat(plan.start_date.replace('Z', '+00:00'))
         end_date = datetime.fromisoformat(plan.end_date.replace('Z', '+00:00'))
@@ -49,7 +50,9 @@ def save_plan(plan: Plan, session: Session, plan_id: int = None):
 def get_plan(plan_id: int, session: Session):
     try:
         plan = session.get(Plan, plan_id)
+        session.commit()
         return plan if plan is not None else None
+
     except Exception as e:
         print("[ plan_repository ] get_plan() 에러 : ", e)
         raise e
@@ -58,6 +61,7 @@ def get_plan(plan_id: int, session: Session):
 def get_member_plans(member_id: int, session: Session):
     try:
         result = session.exec(select(Plan).where(Plan.member_id == member_id)).all()
+
         # serialize_time 유틸리티를 사용하여 변환
         plans = [
             serialize_time.serialize_time(
@@ -69,12 +73,13 @@ def get_member_plans(member_id: int, session: Session):
         
         print("[ plan_repository ] get_member_plans() 결과 : ", plans)
         print("[ plan_repository ] get_member_plans() 결과 타입 : ", type(plans))
+        session.commit()
         return plans
     except Exception as e:
         print("[ plan_repository ] get_member_plans() 에러 : ", e)
         raise e
 
-async def delete_plan(plan_id: int, session: Session):
+def delete_plan(plan_id: int, session: Session):
     try:
         plan = session.get(Plan, plan_id)
         if plan is None:
@@ -85,7 +90,3 @@ async def delete_plan(plan_id: int, session: Session):
     except Exception as e:
         print("[ plan_repository ] delete_plan() 에러 : ", e)
         raise e
-
-
-
-   

--- a/app/repository/plans/plan_spots_repository.py
+++ b/app/repository/plans/plan_spots_repository.py
@@ -10,7 +10,6 @@ def save_plan_spots (plan_id:int, spot_id:int, order:int, day_x:str, spot_time:s
             day_x=day_x,
             spot_time=spot_time
             ))
-        session.commit()
     except Exception as e:
         print("[ planSpotRepository ] save_plan_spots() 에러 : ", e)
         raise e
@@ -20,12 +19,16 @@ def get_plan_spots(plan_id: int, session:Session):
         plan_stmt = select(Plan).where(Plan.id == plan_id)
         plan = session.exec(plan_stmt).first()
 
+        print(f"💡[ plan_spots_repository ] plan : {plan}")
+
         spot_stmt = (
             select(PlanSpotMap, Spot)
             .join(Spot, PlanSpotMap.spot_id == Spot.id)  
             .where(PlanSpotMap.plan_id == plan_id)  
         )
         spots = session.exec(spot_stmt).all() 
+
+        print(f"💡[ plan_spots_repository ] spots : {spots}")
 
         plan_spots_with_spot_info = {
             "plan": plan,
@@ -37,7 +40,6 @@ def get_plan_spots(plan_id: int, session:Session):
             for plan_spot, spot in spots
         ]}
 
-        session.commit()
         return plan_spots_with_spot_info if plan_spots_with_spot_info is not None else None
     except Exception as e:
         print("[ planRepository ] get_plan_spots() 에러 : ", e)

--- a/app/repository/plans/plan_spots_repository.py
+++ b/app/repository/plans/plan_spots_repository.py
@@ -37,7 +37,9 @@ def get_plan_spots(plan_id: int, session:Session):
             for plan_spot, spot in spots
         ]}
 
+        session.commit()
         return plan_spots_with_spot_info if plan_spots_with_spot_info is not None else None
     except Exception as e:
         print("[ planRepository ] get_plan_spots() 에러 : ", e)
+
 

--- a/app/repository/spots/spot_repository.py
+++ b/app/repository/spots/spot_repository.py
@@ -16,6 +16,7 @@ def get_spot(spot_id: int, session:Session) -> Spot:
     try:
         query = select(Spot).where(Spot.id == spot_id)
         spot = session.exec(query).first()
+        session.commit()
         return spot if spot is not None else None
     except Exception as e:
         print("[ spotRepository ] get_spot() 에러 : ", e)

--- a/app/repository/spots/spot_repository.py
+++ b/app/repository/spots/spot_repository.py
@@ -5,7 +5,6 @@ def save_spot(spot: Spot, session:Session):
     try:
         session.add(spot)
         session.flush()
-        session.commit()
         return spot.id
     except Exception as e:
         session.rollback()  # 트랜잭션 롤백
@@ -16,7 +15,6 @@ def get_spot(spot_id: int, session:Session) -> Spot:
     try:
         query = select(Spot).where(Spot.id == spot_id)
         spot = session.exec(query).first()
-        session.commit()
         return spot if spot is not None else None
     except Exception as e:
         print("[ spotRepository ] get_spot() 에러 : ", e)
@@ -27,7 +25,6 @@ def delete_spot(spot_id: int, session:Session):
         query = select(Spot).where(Spot.id == spot_id)
         spot = session.exec(query).first()
         session.delete(spot)
-        session.commit()
         return spot.id
     except Exception as e:
         print("[ spotRepository ] delete_spot() 에러 : ", e)

--- a/app/repository/spots/spot_repository.py
+++ b/app/repository/spots/spot_repository.py
@@ -20,8 +20,18 @@ def get_spot(spot_id: int, session:Session) -> Spot:
     except Exception as e:
         print("[ spotRepository ] get_spot() 에러 : ", e)
         raise e
+    
+def delete_spot(spot_id: int, session:Session):
+    try:
+        query = select(Spot).where(Spot.id == spot_id)
+        spot = session.exec(query).first()
+        session.delete(spot)
+        session.commit()
+        return spot.id
+    except Exception as e:
+        print("[ spotRepository ] delete_spot() 에러 : ", e)
+        raise e
 
-        
 # 샘플 Spot 데이터
 # {
 #   "kor_name": "Test Spot",

--- a/app/routers/plans/plan_router.py
+++ b/app/routers/plans/plan_router.py
@@ -14,6 +14,13 @@ from app.services.plans.plan_service import edit_plan, find_member_plans, find_p
 from app.services.plans.plan_spots_service import find_plan_spots
 from app.services.spots.spot_service import reg_spot
 from app.repository.plans.plan_repository import delete_plan
+import logging
+
+logging.basicConfig()
+logging.getLogger("sqlalchemy.engine").setLevel(logging.DEBUG)
+logging.getLogger("sqlalchemy.pool").setLevel(logging.DEBUG)
+logging.getLogger("sqlalchemy.orm").setLevel(logging.DEBUG)
+
 
 
 router = APIRouter()
@@ -47,7 +54,7 @@ class PlanRequest(BaseModel):
 
 # 일정 저장
 @router.post("")
-def create_plan(request_data: PlanRequest, request: Request, session: Session = Depends(get_session_sync)):
+async def create_plan(request_data: PlanRequest, request: Request, session: Session = Depends(get_session_sync)):
     try:
         # 0. memberid 획득
         if(request.state.user is not None):
@@ -88,42 +95,46 @@ async def read_member_plans(request: Request, session: Session = Depends(get_ses
         return ErrorResponse(message="멤버의 일정정보 조회에 실패했습니다.", error_detail=e)
 
 # 일정 수정
-# @router.post("/{plan_id}")
-# async def update_plan(plan_id: int, request_data: PlanRequest, request: Request, session: Session = Depends(get_session_sync)):
-#     try:
-#         # 0. memberid 획득
-#         if(request.state.user is not None):
-#             member_email = request.state.user.get("email")
-#             member_id = get_memberId_by_email(member_email, session)
-#         else:
-#             member_id = get_memberId_by_email(request_data.email, session)
+@router.post("/{plan_id}")
+async def update_plan(plan_id: int, request_data: PlanRequest, request: Request, session: Session = Depends(get_session_sync)):
+    try:
+        # if(request.state.user is not None):
+        #     member_email = request.state.user.get("email")
+        #     member_id = get_memberId_by_email(member_email, session)
+        # else:
+        #     return ErrorResponse(message="로그인이 필요합니다.")
         
-#         # 1. 일정 수정
-#         edit_plan(plan_id, request_data.plan, member_id, session)
-#         # 2. 장소 수정 - 추가된 장소는 추가, 삭제될 장소는 삭제
-#         spot_ids: List[str] = edit_spot(plan_id, request_data.spots, session)
-#         # 3. 일정-장소 매핑 수정
-#         # save_plan_spots(plan_id, spot_id, spot.order, spot.day_x, spot.spot_time, session)
+        # # 1. 소유자 확인
+        # plan = find_plan(plan_id, session)
+        # if(plan.member_id != member_id):
+        #     return ErrorResponse(message="일정 수정 권한이 없습니다.")
         
-#         return SuccessResponse(data={"plan_id": plan_id}, message="일정이 성공적으로 수정되었습니다.")
-#     except Exception as e:
-
-#         return ErrorResponse(message="일정 수정에 실패했습니다.", error_detail=e)
+        #2. 기존 일정 삭제
+        await erase_plan(plan_id, session)
+        
+        #3. 새로운 일정 등록
+        await create_plan(request_data, request, session)
+        
+        
+        return SuccessResponse(data={"plan_id": plan_id}, message="일정이 성공적으로 수정되었습니다.")
+    except Exception as e:
+        logging.debug(f"💡logger: 일정 수정 오류: {e}")
+        return ErrorResponse(message="일정 수정에 실패했습니다.", error_detail=e)
 
 # 일정 삭제
 @router.delete("/{plan_id}")
 async def erase_plan(plan_id: int, request: Request, session: Session = Depends(get_session_sync)):
     try:
-        if(request.state.user is not None):
-            member_email = request.state.user.get("email")
-            member_id = get_memberId_by_email(member_email, session)
-        else:
-            return ErrorResponse(message="로그인이 필요합니다.")
+        # if(request.state.user is not None):
+        #     member_email = request.state.user.get("email")
+        #     member_id = get_memberId_by_email(member_email, session)
+        # else:
+        #     return ErrorResponse(message="로그인이 필요합니다.")
         
-        # 1. 소유자 확인
-        plan = find_plan(plan_id, session)
-        if(plan.member_id != member_id):
-            return ErrorResponse(message="일정 삭제 권한이 없습니다.")
+        # # 1. 소유자 확인
+        # plan = find_plan(plan_id, session)
+        # if(plan.member_id != member_id):
+        #     return ErrorResponse(message="일정 삭제 권한이 없습니다.")
         
         #1. 장소 삭제
         plan_spots = find_plan_spots(plan_id, session)
@@ -131,12 +142,12 @@ async def erase_plan(plan_id: int, request: Request, session: Session = Depends(
         for spot in plan_spots["detail"]:
             print("💡[ plan_router ] spot : ", spot)
             delete_spot(spot["spot"]["id"], session)
-        
 
         # 2. 일정 삭제
-        await delete_plan(plan_id, session)
+        delete_plan(plan_id, session)
         return SuccessResponse(message="일정이 성공적으로 삭제되었습니다.")
     except Exception as e:
+        logging.debug(f"💡logger: 일정 삭제 오류: {e}")
         return ErrorResponse(message="일정 삭제에 실패했습니다.", error_detail=e)
 
 

--- a/app/routers/plans/plan_router.py
+++ b/app/routers/plans/plan_router.py
@@ -10,7 +10,8 @@ from app.dtos.common.response import ErrorResponse, SuccessResponse
 from app.repository.members.mebmer_repository import get_memberId_by_email
 from app.repository.plans.plan_spots_repository import save_plan_spots
 from app.services.plans.plan_service import edit_plan, find_member_plans, reg_plan
-from app.services.spots.spot_service import edit_spot, reg_spot
+from app.services.spots.spot_service import reg_spot
+from app.repository.plans.plan_repository import delete_plan
 
 
 router = APIRouter()
@@ -85,33 +86,33 @@ async def read_member_plans(request: Request, session: Session = Depends(get_ses
         return ErrorResponse(message="멤버의 일정정보 조회에 실패했습니다.", error_detail=e)
 
 # 일정 수정
-@router.post("/{plan_id}")
-async def update_plan(plan_id: int, request_data: PlanRequest, request: Request, session: Session = Depends(get_session_sync)):
-    try:
-        # 0. memberid 획득
-        if(request.state.user is not None):
-            member_email = request.state.user.get("email")
-            member_id = get_memberId_by_email(member_email, session)
-        else:
-            member_id = get_memberId_by_email(request_data.email, session)
+# @router.post("/{plan_id}")
+# async def update_plan(plan_id: int, request_data: PlanRequest, request: Request, session: Session = Depends(get_session_sync)):
+#     try:
+#         # 0. memberid 획득
+#         if(request.state.user is not None):
+#             member_email = request.state.user.get("email")
+#             member_id = get_memberId_by_email(member_email, session)
+#         else:
+#             member_id = get_memberId_by_email(request_data.email, session)
         
-        # 1. 일정 수정
-        edit_plan(plan_id, request_data.plan, member_id, session)
-        # 2. 장소 수정 - 추가된 장소는 추가, 삭제될 장소는 삭제
-        spot_ids: List[str] = edit_spot(plan_id, request_data.spots, session)
-        # 3. 일정-장소 매핑 수정
-        save_plan_spots(plan_id, spot_id, spot.order, spot.day_x, spot.spot_time, session)
+#         # 1. 일정 수정
+#         edit_plan(plan_id, request_data.plan, member_id, session)
+#         # 2. 장소 수정 - 추가된 장소는 추가, 삭제될 장소는 삭제
+#         spot_ids: List[str] = edit_spot(plan_id, request_data.spots, session)
+#         # 3. 일정-장소 매핑 수정
+#         # save_plan_spots(plan_id, spot_id, spot.order, spot.day_x, spot.spot_time, session)
         
-        return SuccessResponse(data={"plan_id": plan_id}, message="일정이 성공적으로 수정되었습니다.")
-    except Exception as e:
+#         return SuccessResponse(data={"plan_id": plan_id}, message="일정이 성공적으로 수정되었습니다.")
+#     except Exception as e:
 
-        return ErrorResponse(message="일정 수정에 실패했습니다.", error_detail=e)
+#         return ErrorResponse(message="일정 수정에 실패했습니다.", error_detail=e)
 
 # 일정 삭제
 @router.delete("/{plan_id}")
-async def delete_plan(plan_id: int, request: Request, session: Session = Depends(get_session_sync)):
+async def erase_plan(plan_id: int, request: Request, session: Session = Depends(get_session_sync)):
     try:
-        delete_plan(plan_id, session)
+        await delete_plan(plan_id, session)
         return SuccessResponse(message="일정이 성공적으로 삭제되었습니다.")
     except Exception as e:
         return ErrorResponse(message="일정 삭제에 실패했습니다.", error_detail=e)

--- a/app/routers/plans/plan_spots_router.py
+++ b/app/routers/plans/plan_spots_router.py
@@ -7,10 +7,6 @@ from app.repository.db import get_session_sync
 
 router = APIRouter()
 
-# 일정 저장
-@router.post("")
-async def create_plan_spot():
-    pass
 
 @router.get("/{plan_id}")
 async def read_plan_spots(plan_id: int, session: Session = Depends(get_session_sync)):

--- a/app/routers/plans/plan_spots_router.py
+++ b/app/routers/plans/plan_spots_router.py
@@ -1,17 +1,31 @@
 
-from fastapi import APIRouter, Depends
+import logging
+from fastapi import APIRouter, Depends, Request
 from sqlmodel import Session
 from app.dtos.common.response import ErrorResponse, SuccessResponse
+from app.repository.members.mebmer_repository import get_memberId_by_email
 from app.services.plans.plan_spots_service import find_plan_spots
 from app.repository.db import get_session_sync
 
 router = APIRouter()
 
 
+# 일정_장소 조회
 @router.get("/{plan_id}")
-async def read_plan_spots(plan_id: int, session: Session = Depends(get_session_sync)):
+async def read_plan_spots(plan_id: int, request: Request, session: Session = Depends(get_session_sync)):
     try:
+        # #0. 사용자 권한 확인
+        # if(request.state.user is not None):
+        #     member_email = request.state.user.get("email")
+        #     logging.debug(f"💡[ plan_spots_router ] member_email : {member_email}")
+        # else:
+        #     return ErrorResponse(message="로그인이 필요합니다.")
+        
+        #1. 일정_장소 조회
         plan_spots = find_plan_spots(plan_id, session)
+        logging.debug(f"💡[ plan_spots_router ] plan_spots : {plan_spots}")
+        print(f"💡[ plan_spots_router ] plan_spots : {plan_spots}")
+
         return SuccessResponse(data=plan_spots, message="일정과 장소 정보가 성공적으로 조회되었습니다.")
     except Exception as e:
         return ErrorResponse(message="일정과 장소정보 조회에 실패했습니다.", error_detail=e)

--- a/app/services/plans/plan_spots_service.py
+++ b/app/services/plans/plan_spots_service.py
@@ -1,10 +1,13 @@
 
+import logging
 from app.utils.serialize_time import serialize_time
 from app.repository.plans.plan_spots_repository import get_plan_spots
 from sqlmodel import Session
 
 def find_plan_spots(plan_id: int, session: Session):
     plan_spots_with_spot_info = get_plan_spots(plan_id, session)
+    logging.debug(f"💡[ plan_spots_service ] plan_spots_with_spot_info : {plan_spots_with_spot_info}")
+    print(f"💡[ plan_spots_service ] plan_spots_with_spot_info : {plan_spots_with_spot_info}")
     
     #  day_x와 order 순으로 정렬
     plan_spots_with_spot_info["detail"].sort(

--- a/app/services/spots/spot_service.py
+++ b/app/services/spots/spot_service.py
@@ -1,9 +1,12 @@
 
+from typing import List
 from sqlmodel import Session
 from app.data_models.data_model import Spot
-from app.repository.spots.spot_repository import save_spot, get_spot
+from app.repository.spots.spot_repository import delete_spot, save_spot, get_spot
 from datetime import datetime
 
+from app.routers.plans.plan_router import spot_request
+from app.services.plans.plan_spots_service import find_plan_spots
 from app.utils.serialize_time import serialize_time
 
 def reg_spot(spot: Spot, session: Session):
@@ -14,3 +17,56 @@ def find_spot(spot_id: int, session: Session):
     spot = get_spot(spot_id, session)
     serialized_spot = serialize_time(spot,  ["created_at", "updated_at"])
     return serialized_spot
+
+# 이미 존재하는 장소인지 확인
+# 이미 존재하면서 요청 데이터에도 존재하면 내버려둠.
+# 이미 존재하면서 요청 데이터에는 없으면 삭제
+# 이미 존재하지 않으면서 요청 데이터에도 없으면 추가
+def edit_spot(plan_id: int, spots: List[spot_request], session: Session) -> List[int]:
+    plan_spots = find_plan_spots(plan_id, session)
+    spots_from_db = plan_spots["detail"]
+
+    # 반환될 id 리스트
+    spots_ids: List[int] = [spot["spot"].id for spot in spots_from_db]
+
+    # db에서 가져온 장소 이름 뽑아내기
+    spot_names_from_db: List[str] = [spot["spot"].kor_name for spot in spots_from_db]
+    print("[spot_service] spot_names: ", spot_names_from_db)
+
+    # 요청 데이터에서 장소 이름 뽑아내기
+    spot_names_from_request: List[str] = [spot.kor_name for spot in spots]
+    print("[spot_service] spot_names_from_request: ", spot_names_from_request)
+
+    # db 데이터에서 삭제될 장소 이름 추출
+    spots_to_delete: List[str] = [spot_name for spot_name in spot_names_from_db if spot_name not in spot_names_from_request]
+    print("[spot_service] spots_to_delete: ", spots_to_delete)
+
+    # 요청 데이터에서 추가될 장소 이름 추출
+    spots_to_add: List[str] = [spot_name for spot_name in spot_names_from_request if spot_name not in spot_names_from_db]
+    print("[spot_service] spots_to_add: ", spots_to_add)
+
+
+    # 삭제될 장소 삭제
+    # TODO: 한번에 삭제 가능한지 알아보기 
+    for spot_name in spots_to_delete:
+        spot_for_delete = [spot for spot in spots_from_db if spot["spot"].kor_name == spot_name]
+        deleted_spot_id = delete_spot(spot_for_delete[0]["spot"].id, session)
+        spots_ids.remove(deleted_spot_id)
+
+    # 추가될 장소 추가
+    for spot_name in spots_to_add:
+        spot_for_add_preprocess = [spot for spot in spots if spot.kor_name == spot_name]
+        spot_for_add_postprocess = Spot(**spot_for_add_preprocess[0].model_dump(exclude={"order", "day_x", "spot_time"}))
+        save_spot(spot_for_add_postprocess, session)
+        spots_ids.append(spot_for_add_postprocess.id)
+    
+    # 남아있는 장소 아이디 반환
+    return spots_ids
+
+
+
+
+
+
+    
+

--- a/app/services/spots/spot_service.py
+++ b/app/services/spots/spot_service.py
@@ -4,9 +4,6 @@ from sqlmodel import Session
 from app.data_models.data_model import Spot
 from app.repository.spots.spot_repository import delete_spot, save_spot, get_spot
 from datetime import datetime
-
-from app.routers.plans.plan_router import spot_request
-from app.services.plans.plan_spots_service import find_plan_spots
 from app.utils.serialize_time import serialize_time
 
 def reg_spot(spot: Spot, session: Session):
@@ -18,50 +15,50 @@ def find_spot(spot_id: int, session: Session):
     serialized_spot = serialize_time(spot,  ["created_at", "updated_at"])
     return serialized_spot
 
-# 이미 존재하는 장소인지 확인
-# 이미 존재하면서 요청 데이터에도 존재하면 내버려둠.
-# 이미 존재하면서 요청 데이터에는 없으면 삭제
-# 이미 존재하지 않으면서 요청 데이터에도 없으면 추가
-def edit_spot(plan_id: int, spots: List[spot_request], session: Session) -> List[int]:
-    plan_spots = find_plan_spots(plan_id, session)
-    spots_from_db = plan_spots["detail"]
+# # 이미 존재하는 장소인지 확인
+# # 이미 존재하면서 요청 데이터에도 존재하면 내버려둠.
+# # 이미 존재하면서 요청 데이터에는 없으면 삭제
+# # 이미 존재하지 않으면서 요청 데이터에도 없으면 추가
+# def edit_spot(plan_id: int, spots: List[spot_request], session: Session) -> List[int]:
+#     plan_spots = find_plan_spots(plan_id, session)
+#     spots_from_db = plan_spots["detail"]
 
-    # 반환될 id 리스트
-    spots_ids: List[int] = [spot["spot"].id for spot in spots_from_db]
+#     # 반환될 id 리스트
+#     spots_ids: List[int] = [spot["spot"].id for spot in spots_from_db]
 
-    # db에서 가져온 장소 이름 뽑아내기
-    spot_names_from_db: List[str] = [spot["spot"].kor_name for spot in spots_from_db]
-    print("[spot_service] spot_names: ", spot_names_from_db)
+#     # db에서 가져온 장소 이름 뽑아내기
+#     spot_names_from_db: List[str] = [spot["spot"].kor_name for spot in spots_from_db]
+#     print("[spot_service] spot_names: ", spot_names_from_db)
 
-    # 요청 데이터에서 장소 이름 뽑아내기
-    spot_names_from_request: List[str] = [spot.kor_name for spot in spots]
-    print("[spot_service] spot_names_from_request: ", spot_names_from_request)
+#     # 요청 데이터에서 장소 이름 뽑아내기
+#     spot_names_from_request: List[str] = [spot.kor_name for spot in spots]
+#     print("[spot_service] spot_names_from_request: ", spot_names_from_request)
 
-    # db 데이터에서 삭제될 장소 이름 추출
-    spots_to_delete: List[str] = [spot_name for spot_name in spot_names_from_db if spot_name not in spot_names_from_request]
-    print("[spot_service] spots_to_delete: ", spots_to_delete)
+#     # db 데이터에서 삭제될 장소 이름 추출
+#     spots_to_delete: List[str] = [spot_name for spot_name in spot_names_from_db if spot_name not in spot_names_from_request]
+#     print("[spot_service] spots_to_delete: ", spots_to_delete)
 
-    # 요청 데이터에서 추가될 장소 이름 추출
-    spots_to_add: List[str] = [spot_name for spot_name in spot_names_from_request if spot_name not in spot_names_from_db]
-    print("[spot_service] spots_to_add: ", spots_to_add)
+#     # 요청 데이터에서 추가될 장소 이름 추출
+#     spots_to_add: List[str] = [spot_name for spot_name in spot_names_from_request if spot_name not in spot_names_from_db]
+#     print("[spot_service] spots_to_add: ", spots_to_add)
 
 
-    # 삭제될 장소 삭제
-    # TODO: 한번에 삭제 가능한지 알아보기 
-    for spot_name in spots_to_delete:
-        spot_for_delete = [spot for spot in spots_from_db if spot["spot"].kor_name == spot_name]
-        deleted_spot_id = delete_spot(spot_for_delete[0]["spot"].id, session)
-        spots_ids.remove(deleted_spot_id)
+#     # 삭제될 장소 삭제
+#     # TODO: 한번에 삭제 가능한지 알아보기 
+#     for spot_name in spots_to_delete:
+#         spot_for_delete = [spot for spot in spots_from_db if spot["spot"].kor_name == spot_name]
+#         deleted_spot_id = delete_spot(spot_for_delete[0]["spot"].id, session)
+#         spots_ids.remove(deleted_spot_id)
 
-    # 추가될 장소 추가
-    for spot_name in spots_to_add:
-        spot_for_add_preprocess = [spot for spot in spots if spot.kor_name == spot_name]
-        spot_for_add_postprocess = Spot(**spot_for_add_preprocess[0].model_dump(exclude={"order", "day_x", "spot_time"}))
-        save_spot(spot_for_add_postprocess, session)
-        spots_ids.append(spot_for_add_postprocess.id)
+#     # 추가될 장소 추가
+#     for spot_name in spots_to_add:
+#         spot_for_add_preprocess = [spot for spot in spots if spot.kor_name == spot_name]
+#         spot_for_add_postprocess = Spot(**spot_for_add_preprocess[0].model_dump(exclude={"order", "day_x", "spot_time"}))
+#         save_spot(spot_for_add_postprocess, session)
+#         spots_ids.append(spot_for_add_postprocess.id)
     
-    # 남아있는 장소 아이디 반환
-    return spots_ids
+#     # 남아있는 장소 아이디 반환
+#     return spots_ids
 
 
 

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ load_dotenv()
 
 # 로그 설정
 logging.basicConfig(
-    filename="app.log",  # 파일로 저장
+    # filename="app.log",  # 파일로 저장
     level=logging.INFO,  # 로그 레벨 설정
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",  # 로그 형식
 )


### PR DESCRIPTION
## 일정 수정 로직을 추가했습니다.
관련해서 백엔드 로직에 다음의 큰 변화가 있습니다.

1. 모든 리포지토리 계층의 코드에서 명시적 `session.commit()` 제거
2. `db.py`의 `get_session_sync()` 의 `yield` 이후에 `session.commit()` 추가
위의 두 가지를 적용하면 하나의 API가 하나의 트랜잭션만 이용한다는 원칙하에서는 트랜잭션을 추가로 고민할 필요가 없게 됩니다. (라고 생각합니다...)

3. `Plan`과 `Spot`에 각각 row 삭제시 `plna_spots` 에 캐스캐이딩이 적용되도록 했습니다. 
실험해보니 캐스캐이딩은 일대다 관계에서 일에만 적용이 되므로, Plan과 Spot테이블에만 설정할 수 있었습니다.