### PR TITLE
[기능] 일정 수정, 삭제 로직에 체크리스트 서비스로직 추가

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -221,3 +221,4 @@ wheel==0.45.1
 wrapt==1.17.2
 yarl==1.18.3
 zipp==3.21.0
+aiomysql==0.2.0


### PR DESCRIPTION
@864eun 님이 만드신 체크리스트 서비스 메서드를 일정 라우터 로직에 추가했습니다.

만약 해당 서비스 메서드의 구현체가 바뀌더라도, 이름과 함수 인자만 바뀌지 않는다면 별도로 일정 라우터에서 수정해야할 부분은 없습니다.

하지만 이름이나 함수 시그니처가 바뀌면 말씀부탁드립니다.