### PR TITLE
[기능] PlanRequest에 checklist추가

### DIFF
--- a/app/data_models/data_model.py
+++ b/app/data_models/data_model.py
@@ -68,7 +68,7 @@ class Plan(SQLModel, table=True):
     updated_at: Optional[datetime] = None
     
     member: Member = Relationship(back_populates="plans")
-    checklist: Optional["Checklist"] = Relationship(back_populates="plan", cascade_delete=True)
+    checklists: Optional[List["Checklist"]]= Relationship(back_populates="plan", cascade_delete=True)
     plan_spots: List["PlanSpotMap"] = Relationship(back_populates="plan", cascade_delete=True)
 
 class Spot(SQLModel, table=True):

--- a/app/repository/plans/plan_repository.py
+++ b/app/repository/plans/plan_repository.py
@@ -53,6 +53,7 @@ async def save_plan(plan: Plan, session: AsyncSession, plan_id: int = None):
 async def get_plan(plan_id: int, session: AsyncSession):
     try:
         plan = await session.get(Plan, plan_id)
+        print("💡[ plan_repository ] get_plan() 호출 : ", plan)
         return plan if plan is not None else None
 
     except Exception as e:

--- a/app/routers/plans/plan_router.py
+++ b/app/routers/plans/plan_router.py
@@ -126,20 +126,17 @@ async def update_plan(plan_id: int, request_data: PlanRequest, request: Request,
             print("💡[ plan_router ] spot : ", spot)
             await delete_spot(spot["spot"]["id"], session)
 
-        # 2. 일정 삭제
+        # 2. 일정 삭제 -> 체크리스트도 삭제됨(캐스캐이딩)
         await delete_plan(plan_id, session)
 
-        # 3. 체크리스트 삭제
-        await delete_checklist(plan_id, session)
-
-        # 4. 새로운 일정 등록
+        # 2. 새로운 일정 등록
         plan_id = await reg_plan(request_data.plan, member_id, session)
         for spot in request_data.spots:
             spot_id = await reg_spot(Spot(**spot.model_dump(exclude={"order", "day_x", "spot_time"})), session)
             # 3. 일정-장소 매핑 저장
             await save_plan_spots(plan_id, spot_id, spot.order, spot.day_x, spot.spot_time, session)
         
-        # 5. 체크리스트 등록(없다면 무시)
+        # 3. 체크리스트 등록(없다면 무시)
         if(request_data.checklist is not None):
             await save_checklist(request_data.checklist, session)
         
@@ -164,18 +161,15 @@ async def erase_plan(plan_id: int, request: Request, session: AsyncSession = Dep
         if(plan.member_id != member_id):
             return ErrorResponse(message="일정 삭제 권한이 없습니다.")
         
-        #1. 장소 삭제
+        #2. 장소 삭제
         plan_spots = await find_plan_spots(plan_id, session)
         print("💡[ plan_router ] plan_spots : ", plan_spots)
         for spot in plan_spots["detail"]:
             print("💡[ plan_router ] spot : ", spot)
             await delete_spot(spot["spot"]["id"], session)
 
-        # 2. 일정 삭제
+        #3. 일정 삭제
         await delete_plan(plan_id, session)
-
-        # 3. 체크리스트 삭제
-        await delete_checklist(plan_id, session)
 
         return SuccessResponse(message="일정이 성공적으로 삭제되었습니다.")
     except Exception as e:

--- a/app/routers/plans/plan_router.py
+++ b/app/routers/plans/plan_router.py
@@ -3,7 +3,7 @@ from typing import List
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel, Field
 from app.repository.db import get_async_session
-from app.data_models.data_model import Plan, Spot
+from app.data_models.data_model import Checklist, Plan, Spot
 from app.dtos.common.response import ErrorResponse, SuccessResponse
 from app.repository.members.mebmer_repository import get_memberId_by_email
 from app.repository.plans.plan_spots_repository import save_plan_spots
@@ -51,6 +51,7 @@ class PlanRequest(BaseModel):
     plan: Plan
     spots: list[spot_request]
     email: str
+    checklist: Checklist | None = None
 
 # 일정 저장
 @router.post("")
@@ -103,15 +104,18 @@ async def update_plan(plan_id: int, request_data: PlanRequest, request: Request,
         if(request.state.user is not None):
             member_email = request.state.user.get("email")
             member_id = await get_memberId_by_email(member_email, session)
+            print("💡[ plan_router ] member_id : ", member_id)
         # local 테스트용
         elif(request_data.email is not None):
             member_id = await get_memberId_by_email(request_data.email, session)
+            print("💡[ plan_router ] member_id : ", member_id)
         else:
             return ErrorResponse(message="로그인이 필요합니다.")
         
 
         # 1. 소유자 확인
         plan = await find_plan(plan_id, session)
+        print("💡[ plan_router ] plan : ", plan)
         if(plan.member_id != member_id):
             return ErrorResponse(message="일정 수정 권한이 없습니다.")
         
@@ -142,6 +146,7 @@ async def update_plan(plan_id: int, request_data: PlanRequest, request: Request,
         return SuccessResponse(data={"plan_id": plan_id}, message="일정이 성공적으로 수정되었습니다.")
     except Exception as e:
         logging.debug(f"💡logger: 일정 수정 오류: {e}")
+        print("💡[ plan_router ] error : ", e)
         return ErrorResponse(message="일정 수정에 실패했습니다.", error_detail=e)
 
 # 일정 삭제


### PR DESCRIPTION
일정 관련 API들이 사용하는 pydantic모델 `PlanRequest`에 `checklist` 를 추가했습니다. 
Plan table과 checklist테이블이 관계를 맺고 있고, 현재 수정 로직이 일정을 모두 지웠다가 다시 생성하는 것이기 때문에 
이 과정에서 입력값으로 checklist 필드가 필요합니다.

추후 수정 로직이 더 최적화되면 이 부분은 변경될 수도 있습니다.