### PR TITLE
[수정] 중복 이메일 일시 oauth 제공자 구별 로직 추가

### DIFF
--- a/app/repository/members/mebmer_repository.py
+++ b/app/repository/members/mebmer_repository.py
@@ -1,4 +1,5 @@
 
+from typing import Optional
 from sqlmodel import  select
 from app.data_models.data_model import Member
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -21,9 +22,12 @@ async def get_member_by_id(member_id: int, session: AsyncSession) -> Member:
     except Exception as e:
         logger.error(f"[ memberRepository ] get_member_by_id() 에러 : {e}")
 
-async def get_memberId_by_email(email: str, provider: str, session: AsyncSession) -> Member:
+async def get_memberId_by_email(email: str, session: AsyncSession, provider: Optional[str] = None) -> Member:
     try:
-        query = select(Member).where((Member.email == email) & (Member.oauth == provider))
+        if provider is None:
+            query = select(Member).where(Member.email == email)
+        else:
+            query = select(Member).where((Member.email == email) & (Member.oauth == provider))
         result = await session.exec(query)
         member = result.first()
         return member.id if member is not None else None

--- a/app/routers/members/member_router.py
+++ b/app/routers/members/member_router.py
@@ -36,9 +36,10 @@ async def reg_fcm_token(request: Request, fcm_token_request: FcmTokenRequest, se
     try:
         if request.state.user is not None:
             member_email = request.state.user.get("email")
-            member_id = await get_memberId_by_email(member_email, session)
+            provider = request.state.user.get("provider")
+            member_id = await get_memberId_by_email(email=member_email, provider=provider, session=session)
         else:
-            member_id = await get_memberId_by_email(fcm_token_request.email, session)
+            member_id = await get_memberId_by_email(email=fcm_token_request.email, session=session)
 
         # 1. 토큰 저장
         await save_fcm_token(member_id, fcm_token_request.fcm_token, session)

--- a/app/routers/plans/plan_router.py
+++ b/app/routers/plans/plan_router.py
@@ -55,10 +55,11 @@ async def create_plan(request_data: PlanRequest, request: Request, session: Asyn
         if(request.state.user is not None):
             logger.info("request.state.user : ", request.state.user)
             member_email = request.state.user.get("email")
-            member_id = await get_memberId_by_email(member_email, session)
+            provider = request.state.user.get("provider")
+            member_id = await get_memberId_by_email(email=member_email, session=session, provider=provider)
         else:
             logger.info("[ plan_router ] request_data.email : ", request_data.email)
-            member_id = await get_memberId_by_email(request_data.email, session)
+            member_id = await get_memberId_by_email(email=request_data.email, session=session)
             logger.info("[ plan_router ] member_id : ", member_id)
 
         # 1. 일정 저장
@@ -81,7 +82,8 @@ async def read_member_plans(request: Request, session: AsyncSession = Depends(ge
     try:
         if(request.state.user is not None):
             member_email = request.state.user.get("email")
-            member_id = await get_memberId_by_email(member_email, session)
+            provider = request.state.user.get("provider")
+            member_id = await get_memberId_by_email(email=member_email, session=session, provider=provider)
             logger.info("💡[ plan_router ] member_id : ", member_id)
             
         else:
@@ -99,11 +101,12 @@ async def update_plan(plan_id: int, request_data: PlanRequest, request: Request,
     try:
         if(request.state.user is not None):
             member_email = request.state.user.get("email")
-            member_id = await get_memberId_by_email(member_email, session)
+            provider = request.state.user.get("provider")
+            member_id = await get_memberId_by_email(email=member_email, session=session, provider=provider)
             logger.info("💡[ plan_router ] member_id : ", member_id)
         # local 테스트용
         elif(request_data.email is not None):
-            member_id = await get_memberId_by_email(request_data.email, session)
+            member_id = await get_memberId_by_email(email=request_data.email, session=session)
             logger.info("💡[ plan_router ] member_id : ", member_id)
         else:
             return ErrorResponse(message="로그인이 필요합니다.")
@@ -155,7 +158,8 @@ async def erase_plan(plan_id: int, request: Request, session: AsyncSession = Dep
     try:
         if(request.state.user is not None):
             member_email = request.state.user.get("email")
-            member_id = await get_memberId_by_email(member_email, session)
+            provider = request.state.user.get("provider")
+            member_id = await get_memberId_by_email(email=member_email, session=session, provider=provider)
         else:
             return ErrorResponse(message="로그인이 필요합니다.")
         

--- a/app/services/members/member_service.py
+++ b/app/services/members/member_service.py
@@ -11,7 +11,7 @@ async def get_member_id_by_request(request: Request, session: AsyncSession):
         if request.state.user is not None:
             email = request.state.user.get("email")
             provider = request.state.user.get("provider")
-            member_id = await get_memberId_by_email(email, provider, session)
+            member_id = await get_memberId_by_email(email=email, session=session, provider=provider)
             logger.info("💡[ member_service ] get_member_id_by_request() member_id : ", member_id)
             return member_id
         else:


### PR DESCRIPTION
다른 oauth임에도 이메일이 중복된다면 이를 구분하지 못하던 로직을 수정했습니다.