### PR TITLE
Fix: [기능] #165 카페 에이전트 결과 redis 저장 및 조회

### DIFF
--- a/app/dtos/cafe_models.py
+++ b/app/dtos/cafe_models.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel, Field
+from typing import List
+
+# 상세 정보를 위한 중첩 모델
+class CafeDetail(BaseModel):
+    atmosphere: str = Field(..., alias="분위기")
+    signature_menu: str = Field(..., alias="시그니처 메뉴")
+    main_features: str = Field(..., alias="주요 특징")
+    positive_reviews: str = Field(..., alias="긍정 리뷰")
+    negative_reviews: str = Field(..., alias="부정 리뷰")
+
+class CafeData(BaseModel):
+    main_location: str
+    keywords: List[str]
+    n_posting: int
+    placeId: str
+    kor_name: str
+    address: str
+    detail: CafeDetail
+    url: str
+    image_url: str
+    latitude: float
+    longitude: float
+    phone_number: str
+    business_status: bool
+    business_hours: str
+    
+class CafeList(BaseModel):
+    spots: list[CafeData]    

--- a/app/repository/redis_client.py
+++ b/app/repository/redis_client.py
@@ -41,7 +41,7 @@ async def close_redis() -> None:
         logging.info("Redis 연결 종료")
         redis_client = None
 
-def get_redis_client() -> Redis:
+async def get_redis_client() -> Redis:
     """현재 Redis 클라이언트를 반환하는 함수"""
     if not redis_client:
         raise ConnectionError("Redis client is not initialized")
@@ -50,4 +50,4 @@ def get_redis_client() -> Redis:
 # FastAPI 의존성 주입을 위한 함수
 async def get_redis() -> Redis:
     """의존성 주입을 위한 Redis 클라이언트 제공 함수"""
-    return get_redis_client()
+    return await get_redis_client()

--- a/app/routers/agents/cafe_agent_router.py
+++ b/app/routers/agents/cafe_agent_router.py
@@ -1,20 +1,30 @@
 from typing import Optional
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from app.services.agents.cafe_agent_service import CafeAgentService
 from app.routers.agents.travel_all_schedule_agent_router import TravelPlanRequest
-from datetime import datetime
+from app.repository.redis_client import get_redis  # Redis 연결 함수
+from app.repository.db import get_async_session
+from sqlalchemy.ext.asyncio import AsyncSession
+from redis.asyncio import Redis
 router = APIRouter()
 
 cafe_service = CafeAgentService()
 
 @router.post("/cafe")
-async def get_cafes(user_input: TravelPlanRequest, prompt:Optional[str]):
+async def get_cafes(
+    user_input: TravelPlanRequest,
+    prompt:Optional[str],
+    redis_client: Redis = Depends(get_redis)
+    ):
     """
     카페 정보를 가져오는 엔드포인트.
     - CrewAI 실행 후 일정(JSON) 반환.
     """
     try:
-        result = await cafe_service.create_recommendation(user_input.model_dump(),prompt=prompt)     
+        result = await cafe_service.create_recommendation(user_input.model_dump(),
+                                                          prompt = prompt,
+                                                          redis_client= redis_client,
+                                                        )     
         if not result:
             print("카페 결과값이 없습니다. ")
 

--- a/app/routers/redis_test.py
+++ b/app/routers/redis_test.py
@@ -1,13 +1,132 @@
-from fastapi import APIRouter, Depends
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException
 from redis.asyncio import Redis
 from app.repository.redis_client import get_redis
-
+from pydantic import BaseModel
 router = APIRouter()
 
-@router.get("/test")
-async def test_redis(redis: Redis = Depends(get_redis)):
-    # Redis에 key-value 저장
-    await redis.set("test_key_again", "test_value_again")
-    # Redis에서 값 조회
-    value = await redis.get("test_key_again")
-    return {"value": value}
+# 테스트 데이터 모델
+class RedisItem(BaseModel):
+    key: str
+    value: str
+    expires_in: Optional[int] = None  # 만료 시간(초)
+
+# Post 테스트
+@router.post("/items")
+async def create_item(
+    item: RedisItem,
+    redis: Redis = Depends(get_redis)
+):
+    # 이미 존재하는 키인지 확인
+    exists = await redis.exists(item.key)
+    if exists:
+        raise HTTPException(
+            status_code=400,
+            detail="Key already exists"
+        )
+    
+    if item.expires_in:
+        # 만료 시간이 설정된 경우
+        await redis.set(
+            item.key,
+            item.value,
+            ex=item.expires_in
+        )
+    else:
+        # 만료 시간이 없는 경우
+        await redis.set(item.key, item.value)
+    
+    return {
+        "message": "Successfully created",
+        "key": item.key,
+        "value": item.value
+    }
+
+# 테스트 GET
+@router.get("/items/{key}")
+async def read_item(
+    key: str,
+    redis: Redis = Depends(get_redis)
+):
+    value = await redis.get(key)
+    if value is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Key not found"
+        )
+    
+    # 만료까지 남은 시간 확인 (초)
+    ttl = await redis.ttl(key)
+    
+    return {
+        "key": key,
+        "value": value,
+        "ttl": ttl if ttl > 0 else None
+    }
+
+# 테스트 Update 
+@router.put("/items/{key}")
+async def update_item(
+    key: str,
+    item: RedisItem,
+    redis: Redis = Depends(get_redis)
+):
+    # 키가 존재하는지 확인
+    exists = await redis.exists(key)
+    if not exists:
+        raise HTTPException(
+            status_code=404,
+            detail="Key not found"
+        )
+    
+    if item.expires_in:
+        await redis.set(
+            key,
+            item.value,
+            ex=item.expires_in
+        )
+    else:
+        await redis.set(key, item.value)
+    
+    return {
+        "message": "Successfully updated",
+        "key": key,
+        "value": item.value
+    }
+
+# 테스트 Delete 
+@router.delete("/items/{key}")
+async def delete_item(
+    key: str,
+    redis: Redis = Depends(get_redis)
+):
+    # 키가 존재하는지 확인
+    exists = await redis.exists(key)
+    if not exists:
+        raise HTTPException(
+            status_code=404,
+            detail="Key not found"
+        )
+    
+    await redis.delete(key)
+    return {"message": f"Successfully deleted key: {key}"}
+
+# 모든 키 조회 (List)
+@router.get("/items")
+async def list_items(
+    pattern: str = "*",
+    redis: Redis = Depends(get_redis)
+):
+    keys = await redis.keys(pattern)
+    items = []
+    
+    for key in keys:
+        value = await redis.get(key)
+        ttl = await redis.ttl(key)
+        items.append({
+            "key": key,
+            "value": value,
+            "ttl": ttl if ttl > 0 else None
+        })
+    
+    return {"items": items}

--- a/app/services/agents/cafe_agent_service.py
+++ b/app/services/agents/cafe_agent_service.py
@@ -7,8 +7,39 @@ from typing import Dict, Optional
 import os
 from dotenv import load_dotenv
 from app.utils.time_check import time_check
+from app.dtos.cafe_models import CafeList
 load_dotenv()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+from fastapi import HTTPException, Depends
+from app.repository.redis_client import get_redis
+from redis.asyncio import Redis
+import json
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def save_cafe_info(cafe_data_list:CafeList, redis_client:Redis):
+    try:
+        for cafe_data in cafe_data_list:
+            cafe_id = cafe_data["placeId"]
+            redis_client.set(f"cafe:{cafe_id}", json.dumps(cafe_data))
+            tags = [cafe_data["main_location"]] + cafe_data["keywords"]
+            for tag in tags:
+                redis_client.sadd(f"tag:{tag}", cafe_id)
+        return "[CafeAgentService] : 성공적으로 저장되었습니다."
+    except Exception as e:
+        error_details = traceback.format_exc()
+        print(f"[CafeAgentService] - save_cafe_info : 저장 중 오류 발생: {error_details}")
+        return f"[CafeAgentService] - save_cafe_info :저장 중 오류 발생: {str(e)}"
+
+    
+async def search_cafes(main_location:str, redis_client:Redis):
+    """ 특정 지역의 모든 카페 조회 """
+    # 해당 지역의 카페 ID들 조회
+    cafe_ids = await redis_client.smembers(f"tag:{main_location}")
+    
+    # 카페 상세 정보 조회
+    results = [json.loads(await redis_client.get(f"cafe:{cafe_id}")) for cafe_id in cafe_ids]
+    return results
             
 class CafeAgentService:
     """
@@ -34,15 +65,10 @@ class CafeAgentService:
         self.agents = self._create_agents()
         self.tasks = self._create_tasks()
         
-        if "collector_task" in self.tasks and "researcher" in self.tasks:
-            self.tasks["researcher_task"].context = [self.tasks["collector_task"]]
-            
-        if "researcher_task" in self.tasks and "reviewer_task" in self.tasks:
-            self.tasks["reviewer_task"].context = [self.tasks["researcher_task"]]
-    
-        if "researcher_task" in self.tasks and "Decider_task" in self.tasks:
-            self.tasks["Decider_task"].context = [self.tasks["reviewer_task"]]
-        
+        self.tasks["researcher_task"].context = [self.tasks["collector_task"]]
+        self.tasks["reviewer_task"].context = [self.tasks["researcher_task"]]
+        self.tasks["Decider_task"].context = [self.tasks["reviewer_task"]]
+        self.draft_crew = Crew(agents=[self.agents['collector']], tasks=[self.tasks['collector_task']], verbose=True)  
         self.crew = Crew(agents=list(self.agents.values()), tasks=list(self.tasks.values()),process=Process.sequential, verbose=True)  
 
     def _create_agents(self) -> Dict[str, Agent]:
@@ -86,7 +112,7 @@ class CafeAgentService:
                 verbose=True,
                 stop_on_failure=True
             ),
-            "Decider" : Agent(
+            "decider" : Agent(
                 role="고객의 요구사항을 가장 많이 반영한 카페 선정",
                 goal="고객의 여행지에서 인기있고, 고객의 선호도를 반영한 카페를 선정합니다.",
                 backstory="""
@@ -149,68 +175,96 @@ class CafeAgentService:
                 2. researcher가 반환한 값에 tool_output의 정보를 합쳐 반환해주세요. 
                 3. 카페 특징은 Decider가 고객 요구사항에 맞는 카페인지 점검할 수 있도록 구체적으로 써주세요.
                 4. 포스팅 횟수가 많고, 긍정적인 리뷰가 많은 카페부터 나열해주세요.
+                5. 리뷰를 보고, 카페가 아닌 식당, 미용실, 호텔, 리조트 등의 경우 삭제해주세요.
                 """,
                 expected_output="""
                 중복되지 않는 카페 리스트를 반환해주세요.
-                - 이름
-                - 포스팅 횟수
-                - 카페 특징(분위기, 시그니처 메뉴, 주요 특징, 긍정 리뷰, 부정 리뷰 요약)
-                - placeId
-                - 주소
-                - 이미지url
-                - 위도
-                - 경도
-                - 전화번호
-                - 홈페이지url
-                - 운영 시간(모르는 경우 "정보 없음")
                 """,        
                 agent=self.agents["reviewer"],
-                context=[]
+                output_json=CafeList,
+                context=[],
+                callback=save_cafe_info
             ),
-            "Decider_task" : Task(
+            "decider_task" : Task(
                 description="""
                 1. 고객의 요구사항({prompt}), 여행 컨셉({concepts}), 주 연령대({ages})가 반영된 카페를 가장 우선적으로 선택하세요.
-                2. reviewer가 반환한 특징을 참고해 포스팅 횟수가 많고, 긍정적인 리뷰가 많은 카페부터 나열해주세요.
-                3. reviewer가 반환한 카페들의 placeId를 리스트로 묶어 tool의 input값으로 사용해 각 카페의 운영 시간과 웹사이트 정보를 수집하세요.
+                2. 포스팅 횟수가 많고, 긍정적인 리뷰가 많은 카페부터 나열해주세요.
+                3. placeId를 리스트로 묶어 tool의 input값으로 사용해 각 카페의 운영 시간과 웹사이트 정보를 수집하세요.
                 4. description에는 카페의 주요 특징과 시그니처메뉴, 사람들이 공통적으로 좋아했던 부분을 요약해주세요.
-                모르는 정보는 지어내지 말고 "정보 없음"으로 작성하세요.
-                {main_location}에 위치한 카페만 선택하세요.
-                호텔, 리조트 등의 숙소나 미용실 등 다른 업종인 경우 선택하지 마세요.
+                5. 모르는 정보는 지어내지 말고 "정보 없음"으로 작성하세요.
+                6. {main_location}에 위치한 카페만 선택하세요.
+                7. 호텔, 리조트 등의 숙소나 미용실 등 다른 업종인 경우 선택하지 마세요.
+                참고 카페 리스트 : {cached_cafe_lists}
                 """,
                 expected_output="""
-                prompt({prompt})가 유효한 값(빈 문자열(""), None, 또는 null이 아닌 경우)이면 5개의 카페를, 그렇지 않으면 {n}*2개의 카페를 반환하세요.                spot_time 예상 방문 시간을 `hh:00` 형식으로 반환하고, 모두 다른 값으로 해주세요.
+                prompt({prompt})가 유효한 값(빈 문자열(""), None, 또는 null이 아닌 경우)이면 5개의 카페를, 그렇지 않으면 {n}*2개의 카페를 반환하세요.
+                spot_time 예상 방문 시간을 `hh:00` 형식으로 반환하고, 모두 다른 값으로 해주세요.
                 order는 방문할 순서입니다. spot_time을 기준으로 빠른 시간부터 오름차순 정렬해주세요. 순서는 1부터 시작합니다.
                 spot_category는 항상 3으로 고정해주세요
                 day_x는 {n}일의 여행 일정 중 몇일차인지 입니다.(만약, day_x:1 이라면 1일차에 방문한다는 의미)  
                 business_status는 boolean으로 반환해주세요.
                 """,
                 context=[],        
-                agent=self.agents["Decider"],
+                agent=self.agents["decider"],
                 output_pydantic=spots_pydantic
             )
         }     
     @time_check   
-    async def create_recommendation(self, input_data: dict, prompt: Optional[str] = None) -> dict:
+    async def create_recommendation(self, input_data: dict, 
+                                    prompt: Optional[str] = None,
+                                    redis_client: Redis = None) -> dict:
         """
         사용자 맞춤 카페를 추천하는 에이전트
         """
         if input_data is None:
             raise ValueError("[CafeAgent] 에러 - input_data이 없습니다. 잘못된 요청을 보냈는지 확인해주세요")
-
-        input_data["concepts"] = ', '.join(input_data.get('concepts',''))
+       
+        input_data["concepts"] = ', '.join(input_data.get('concepts',[]))
         input_data["prompt"] = prompt
         input_data["n"] = calculate_trip_days(input_data.get('start_date',''),input_data.get('end_date',''))
+
+        if redis_client is None:
+            raise ValueError("[CafeAgent] 에러 - Redis 연결을 확인해주세요")
+  
+        try:
+            cached_cafe_lists = await search_cafes(input_data["main_location"], redis_client)
+            print(f"cached_cafe_lists: {cached_cafe_lists}")
+            if len(cached_cafe_lists) < (input_data["n"])*2:
+                try:
+                    result = await self.crew.kickoff_async(inputs=input_data)
+                    save_cafe_info()
+                    return result.pydantic.model_dump()
+                except Exception as e:
+                    print(f"[CafeAgent] 에러: {e}")
+                    error_details = traceback.format_exc()
+                    print(f"[CafeAgent] 상세 에러: {error_details}")
+                    raise e  # 또는 적절한 에러 메시지를 담아 반환                   
+            else:
+                input_data["cached_cafe_lists"] = cached_cafe_lists
+                try:
+                    result = await self.draft_crew.kickoff_async(inputs=input_data)
+                    print(f"result:{result}")
+                    return result.pydantic.model_dump()
+                except Exception as e:
+                    print(f"[CafeAgent] 에러: {e}")
+                    error_details = traceback.format_exc()
+                    print(f"[CafeAgent] 상세 에러: {error_details}")
+                    raise e  # 또는 적절한 에러 메시지를 담아 반환   
+                
+        except Exception as e:
+            print(f"[CafeAgent] 에러 - redis에서 정보 불러오기 실패: {e}")    
         
-        # 실행
+        if cached_cafe_lists:
+            return None
         try:
             result = await self.crew.kickoff_async(inputs=input_data)
             print(f"result:{result}")
             return result.pydantic.model_dump()
         except Exception as e:
             print(f"[CafeAgent] 에러: {e}")
-            error_details = traceback.format_exc()  # 전체 오류 스택 추적
-            print(f"[CafeAgent] 상세 에러: {error_details}")  # 터미널에 상세 오류 출력
-               
+            error_details = traceback.format_exc()
+            print(f"[CafeAgent] 상세 에러: {error_details}")
+            raise e  # 또는 적절한 에러 메시지를 담아 반환               
                 
 # {
 #   "ages": "20대",

--- a/app/services/agents/cafe_agent_service.py
+++ b/app/services/agents/cafe_agent_service.py
@@ -17,29 +17,40 @@ import json
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-def save_cafe_info(cafe_data_list:CafeList, redis_client:Redis):
+async def save_cafe_info(cafe_data_list: dict, redis_client:Redis):
     try:
-        for cafe_data in cafe_data_list:
+        # 개별 카페 데이터 저장
+        for cafe_data in cafe_data_list.get("spots", []):
             cafe_id = cafe_data["placeId"]
-            redis_client.set(f"cafe:{cafe_id}", json.dumps(cafe_data))
+            await redis_client.set(f"cafe:{cafe_id}", json.dumps(cafe_data))
+            
             tags = [cafe_data["main_location"]] + cafe_data["keywords"]
             for tag in tags:
-                redis_client.sadd(f"tag:{tag}", cafe_id)
+                await redis_client.sadd(f"tag:{tag}", cafe_id)
         return "[CafeAgentService] : 성공적으로 저장되었습니다."
+
     except Exception as e:
         error_details = traceback.format_exc()
         print(f"[CafeAgentService] - save_cafe_info : 저장 중 오류 발생: {error_details}")
-        return f"[CafeAgentService] - save_cafe_info :저장 중 오류 발생: {str(e)}"
+        return f"[CafeAgentService] - save_cafe_info : 저장 중 오류 발생: {str(e)}"
+            
+async def get_cafes_by_tag(tag: str, redis_client: Redis):
+    """
+    특정 태그(지역 또는 키워드)에 해당하는 모든 카페 조회
+    """
+    cafe_ids = await redis_client.smembers(f"tag:{tag}")  # 태그에 해당하는 placeId 리스트 가져오기
 
-    
-async def search_cafes(main_location:str, redis_client:Redis):
-    """ 특정 지역의 모든 카페 조회 """
-    # 해당 지역의 카페 ID들 조회
-    cafe_ids = await redis_client.smembers(f"tag:{main_location}")
-    
-    # 카페 상세 정보 조회
-    results = [json.loads(await redis_client.get(f"cafe:{cafe_id}")) for cafe_id in cafe_ids]
-    return results
+    if not cafe_ids:
+        print(f"[CafeAgentService] - 태그 '{tag}'에 해당하는 카페를 찾을 수 없습니다.")
+        return None
+    cafes = []
+    for cafe_id in cafe_ids:
+        cafe_data = await redis_client.get(f"cafe:{cafe_id}")
+        if cafe_data:
+            cafes.append(json.loads(cafe_data))
+
+    return cafes
+            
             
 class CafeAgentService:
     """
@@ -67,8 +78,8 @@ class CafeAgentService:
         
         self.tasks["researcher_task"].context = [self.tasks["collector_task"]]
         self.tasks["reviewer_task"].context = [self.tasks["researcher_task"]]
-        self.tasks["Decider_task"].context = [self.tasks["reviewer_task"]]
-        self.draft_crew = Crew(agents=[self.agents['collector']], tasks=[self.tasks['collector_task']], verbose=True)  
+        self.tasks["decider_task"].context = [self.tasks["reviewer_task"]]
+        self.draft_crew = Crew(agents=[self.agents['decider']], tasks=[self.tasks['decider_task']], verbose=True)  
         self.crew = Crew(agents=list(self.agents.values()), tasks=list(self.tasks.values()),process=Process.sequential, verbose=True)  
 
     def _create_agents(self) -> Dict[str, Agent]:
@@ -131,7 +142,7 @@ class CafeAgentService:
             "collector_task" : Task(
                 description="""
                 1. tool 사용시 "{main_location}"과 "keywords"를 순서대로 입력하세요.
-                - keywords : 고객의 요구사항({prompt}), 여행 컨셉({concepts}을 반영한 키워드 리스트
+                - keywords : 고객의 요구사항({prompt}), 여행 컨셉({concepts})을 반영한 키워드 리스트
                 2. 카페별로 포스팅 된 url을 모아 정리하고, 설명을 요약해주세요.
                 3. 포스팅 횟수가 많은 카페 순으로 내림차순 정렬해주세요
                 4. 포스팅 횟수가 동일한 카페들은 "비추' 등의 부정적인 의견이 적은 포스팅부터 먼저 나열해주세요. 
@@ -179,11 +190,11 @@ class CafeAgentService:
                 """,
                 expected_output="""
                 중복되지 않는 카페 리스트를 반환해주세요.
+                main_location: {main_location}
                 """,        
                 agent=self.agents["reviewer"],
-                output_json=CafeList,
-                context=[],
-                callback=save_cafe_info
+                output_pydantic=CafeList,
+                context=[]
             ),
             "decider_task" : Task(
                 description="""
@@ -227,12 +238,17 @@ class CafeAgentService:
             raise ValueError("[CafeAgent] 에러 - Redis 연결을 확인해주세요")
   
         try:
-            cached_cafe_lists = await search_cafes(input_data["main_location"], redis_client)
+            cached_cafe_lists = await get_cafes_by_tag(input_data["main_location"], redis_client) or []
             print(f"cached_cafe_lists: {cached_cafe_lists}")
+            input_data["cached_cafe_lists"] = cached_cafe_lists
+            
             if len(cached_cafe_lists) < (input_data["n"])*2:
                 try:
                     result = await self.crew.kickoff_async(inputs=input_data)
-                    save_cafe_info()
+                    reviewer_result = self.tasks['reviewer_task'].output.pydantic.model_dump()
+                    print(f"result_task3_output_raw:{reviewer_result}")
+                    await save_cafe_info(reviewer_result,redis_client)
+                    print(f"result : {result}")
                     return result.pydantic.model_dump()
                 except Exception as e:
                     print(f"[CafeAgent] 에러: {e}")
@@ -240,10 +256,9 @@ class CafeAgentService:
                     print(f"[CafeAgent] 상세 에러: {error_details}")
                     raise e  # 또는 적절한 에러 메시지를 담아 반환                   
             else:
-                input_data["cached_cafe_lists"] = cached_cafe_lists
                 try:
                     result = await self.draft_crew.kickoff_async(inputs=input_data)
-                    print(f"result:{result}")
+                    print(f"result-draft-crew:{result}")
                     return result.pydantic.model_dump()
                 except Exception as e:
                     print(f"[CafeAgent] 에러: {e}")
@@ -252,19 +267,7 @@ class CafeAgentService:
                     raise e  # 또는 적절한 에러 메시지를 담아 반환   
                 
         except Exception as e:
-            print(f"[CafeAgent] 에러 - redis에서 정보 불러오기 실패: {e}")    
-        
-        if cached_cafe_lists:
-            return None
-        try:
-            result = await self.crew.kickoff_async(inputs=input_data)
-            print(f"result:{result}")
-            return result.pydantic.model_dump()
-        except Exception as e:
-            print(f"[CafeAgent] 에러: {e}")
-            error_details = traceback.format_exc()
-            print(f"[CafeAgent] 상세 에러: {error_details}")
-            raise e  # 또는 적절한 에러 메시지를 담아 반환               
+            print(f"[CafeAgent] 에러 - {e}")                
                 
 # {
 #   "ages": "20대",

--- a/app/services/agents/tools/cafe_tool.py
+++ b/app/services/agents/tools/cafe_tool.py
@@ -84,6 +84,59 @@ def simplify_address(region: str) -> str:
         
     return result
 
+class RedisCafeSearchTool(BaseTool):
+    name: str = "RedisCafeSearchTool"
+    description: str = "Redis에서 특정 위치의 카페 정보 검색"
+
+    async def _fetch_query(self, client: httpx.AsyncClient, query: str) -> str:
+
+        url = "https://openapi.naver.com/v1/search/blog.json"
+        headers = {
+            "X-Naver-Client-Id": AGENT_NAVER_CLIENT_ID,
+            "X-Naver-Client-Secret": AGENT_NAVER_CLIENT_SECRET,
+        }
+        params = {"query": query, "display": 20, "start": 1, "sort": "sim"}
+        try:
+            resp = await client.get(url, headers=headers, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+            items = data.get("items", [])
+            if not items:
+                return f"[NaverBlogSearchTool] '{query}' 검색 결과 없음."
+            results = []
+            for item in items:
+                title = item.get("title", "")
+                link = item.get("link", "")
+                desc = item.get("description", "")
+                results.append(f"제목: {title}\n링크: {link}\n설명: {desc}\n")
+            result_text = "\n".join(results)
+            return f"검색 쿼리: {query}\n결과:\n{result_text}"
+        except Exception as e:
+            return f"[NaverBlogSearchTool] 검색 쿼리 {query} 에러: {str(e)}"
+        
+    async def _arun(self, main_location: str, keywords:List[str]) -> str:
+        if not AGENT_NAVER_CLIENT_ID or not AGENT_NAVER_CLIENT_SECRET:
+            return "[NaverBlogSearchTool] 네이버 API 자격 증명이 없습니다."
+        
+        simplified_location = simplify_address(main_location)
+        # keywords가 비어있으면 기본 검색어를 사용
+        if keywords:
+            keywords_query = f"{simplified_location} 카페 +{' +'.join(keywords)}"
+        else:
+            keywords_query = f"{simplified_location} 카페"
+        
+        querys =[keywords_query, simplified_location+" 카페", simplified_location+" 느좋 카페"]
+        
+        async with httpx.AsyncClient() as client:
+            # 각 검색어마다 비동기 요청(task)을 생성합니다.
+            tasks = [self._fetch_query(client, query) for query in querys]
+            results = await asyncio.gather(*tasks)
+            # 각 검색 결과를 구분하기 위해 빈 줄 두 개로 연결
+            return "\n---------------\n".join(results)
+            
+    def _run(self, main_location: str, keywords:List[str]) -> str:
+        return asyncio.run(self._arun(main_location, keywords))
+    
 class NaverBlogSearchTool(BaseTool):
     name: str = "NaverBlogSearch"
     description: str = "네이버 웹 검색 API를 사용해 카페 검색"

--- a/main.py
+++ b/main.py
@@ -233,6 +233,6 @@ app.include_router(restaurant_agent_router, prefix="/agents", tags=["agents"])
 app.include_router(site_agent_router, prefix="/agents", tags=["agents"])
 app.include_router(cafe_router, prefix="/agents", tags=["agents"])
 app.include_router(checklist_router, prefix="/checklist", tags=["checklists"])
-app.include_router(redis_test_router, prefix="/redis", tags=["redis"])
+app.include_router(redis_test_router, prefix="/redis-test", tags=["redis-test"])
 
 


### PR DESCRIPTION
[작업내용]
1. reviewr task 결과 redis에 저장 및 조회 기능 추가
2. 카페 에이전트 로직 수정
[기존] collector → researcher → reviewer → decider : crew
[변경] redis에 main_location 검색  → 자료 충분히 있으면 decider로만 이루어진 draft_crew 실행, 카페 수 부족하면 crew실행 

[이후 작업 계획]
1. cafe_tool map url카카오로 변경
2. 웹사이트, 운영시간 decider가 조회하는데 reviewer나 researcher가 하도록 수정하고 redis에 같이 저장
3. redis 자료 저장시 데이터 구조 변경, 데이터 저장 시간 변경(예:하루 단위)
