### PR TITLE
Fix:[기능]관광지 데이터: spot_category 1 고정 및 카카오 API를 통한 위도/경도 업데이트 추가

### DIFF
--- a/app/dtos/site_models.py
+++ b/app/dtos/site_models.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from typing import List, Optional
 
+
 class TouristSite(BaseModel):
     placeId: str
     kor_name: str
@@ -13,6 +14,9 @@ class TouristSite(BaseModel):
     phone_number: Optional[str] = None
     business_status: Optional[bool] = None
     business_hours: Optional[str] = None
+    latitude: float = None
+    longitude: float = None
+
 
 class TouristSiteList(BaseModel):
     spots: List[TouristSite]

--- a/app/services/agents/site_agent_service.py
+++ b/app/services/agents/site_agent_service.py
@@ -9,25 +9,28 @@ from redis.asyncio import Redis
 import logging
 import os
 from dotenv import load_dotenv
+
+
 from app.repository.members.mebmer_repository import get_memberId_by_email
 from app.dtos.site_models import TouristSite, TouristSiteList
 from app.utils.calculate_trip_days import calculate_trip_days
 from app.utils.time_check import time_check
 
-# DB 관련 함수
+
 from app.repository.agents.site_plan_spots_repository import (
     get_member_plan_spots,
     get_latest_plan,
 )
 
-# Redis 서비스
+
 from app.services.agents.redis.spot_redis import SpotRedisService, SpotCategory
 
-# Tool 클래스들 (관광지 관련)
+
 from app.services.agents.tools.site_tool import (
     NaverTouristWebSearchTool,
     NaverTouristImageSearchTool,
     NaverTouristBusinessInfoTool,
+    KakaoGeocodeTool,
 )
 
 load_dotenv()
@@ -62,15 +65,16 @@ class TouristAgentService:
             temperature=0,
             max_tokens=4000,
         )
-        # 관광지 리스트, 이미지, 상세 정보용 도구
         self.get_tourist_list_tool = NaverTouristWebSearchTool()
         self.get_tourist_info_tool = NaverTouristImageSearchTool()
         self.get_tourist_business_info_tool = NaverTouristBusinessInfoTool()
-        # 리뷰 대신 웹 검색 결과를 통한 관광지 설명 추출 도구
         self.get_tourist_description_tool = NaverTouristWebSearchTool()
+        self.kakao_tool = KakaoGeocodeTool()
         self.agents = self._create_agents()
         self.tasks = self._create_tasks({})
-        logger.info("TouristAgentService initialized with agents: %s", list(self.agents.keys()))
+        logger.info(
+            "TouristAgentService initialized with agents: %s", list(self.agents.keys())
+        )
 
     def _create_agents(self) -> Dict[str, Agent]:
         return {
@@ -142,8 +146,14 @@ class TouristAgentService:
 
     def _create_tasks(self, input_data: dict, prompt_text: str = "") -> Dict[str, Task]:
         companion_text = (
-            ", ".join([f"{c.get('label', '미지정')} {c.get('count', 0)}명" for c in input_data.get("companion_count", [])])
-            if input_data.get("companion_count") else "동반자 정보 없음"
+            ", ".join(
+                [
+                    f"{c.get('label', '미지정')} {c.get('count', 0)}명"
+                    for c in input_data.get("companion_count", [])
+                ]
+            )
+            if input_data.get("companion_count")
+            else "동반자 정보 없음"
         )
         existing_spots = input_data.get("existing_spot_names", [])
         existing_spots_text = ", ".join(existing_spots) if existing_spots else "없음"
@@ -156,7 +166,7 @@ class TouristAgentService:
             '  "url": string or null,\n'
             '  "image_url": string,\n'
             '  "map_url": string,\n'
-            '  "spot_category": number,\n'
+            '  "spot_category": 1,\n'
             '  "phone_number": string or null,\n'
             '  "business_status": boolean or null,\n'
             '  "business_hours": string or null\n'
@@ -173,7 +183,7 @@ class TouristAgentService:
                     f"이전 Task에서 얻은 {main_location}의 좌표와 여행 정보를 바탕으로 관광지 검색에 사용할 "
                     f"가장 효과적인 검색 키워드 3개를 생성해주세요:\n"
                     f"# 입력 정보\n지역: {main_location}\n"
-                    f"좌표: {{coordinates}}\n"  # input_data에 "coordinates" 키 필요
+                    f"좌표: {{coordinates}}\n"
                     f"여행 기간: {input_data.get('start_date', '')} ~ {input_data.get('end_date', '')}\n"
                     f"연령대: {input_data.get('ages', '연령대 미지정')}\n"
                     f"동반자: {companion_text}\n"
@@ -206,11 +216,11 @@ class TouristAgentService:
                     f"# 입력 정보\n지역: {main_location}\n"
                     "웹 검색 결과에서 관광지에 관한 정보를 종합하여, 관광지의 특징과 설명을 간략하게 요약하고 반환하세요.\n"
                     "반환 형식은 다음과 같습니다:\n"
-                    '{{"kor_name": "관광지 이름", "eng_name": null, "address": "주소", "url": null, "image_url": "이미지 URL", "map_url": "지도 URL", "spot_category": 번호, "phone_number": null, "business_status": null, "business_hours": null}}'
+                    '{{"kor_name": "관광지 이름", "eng_name": null, "address": "주소", "url": null, "image_url": "이미지 URL", "map_url": "지도 URL", "spot_category": 1, "phone_number": null, "business_status": null, "business_hours": null}}'
                 ),
                 agent=self.agents["reviewer"],
                 expected_output=f"{main_location}의 관광지 웹 검색 결과 (JSON array)",
-                output_pydantic=TouristSiteList
+                output_pydantic=TouristSiteList,
             ),
             "decider_task": Task(
                 description=(
@@ -220,43 +230,85 @@ class TouristAgentService:
                     f"여행 기간 {input_data.get('start_date', '')} ~ {input_data.get('end_date', '')}에 적합한 관광지를 선정하세요.\n"
                     "만약 이전 태스크의 데이터가 없거나 부족한 경우, "
                     f"{main_location} 내에서 인기 있는 관광지를 추천하세요.\n"
-                    "반드시 아래 JSON 스키마에 맞추어 결과를 반환하세요:\n" + json_schema_prompt
+                    "반드시 아래 JSON 스키마에 맞추어 결과를 반환하세요. spot_category는 반드시 1로 설정하세요:\n"
+                    + json_schema_prompt
                 ),
                 agent=self.agents["decider"],
                 expected_output=f"{main_location}의 최종 관광지 추천 결과 (JSON array)",
-                output_pydantic=TouristSiteList
+                output_pydantic=TouristSiteList,
             ),
         }
 
     async def filter_image(self, image_url: str) -> bool:
-        # 관광지 사진에서는 인물 이미지가 필요 없으므로, 'profile'이나 'person'이 포함되면 제외합니다.
         if "profile" in image_url or "person" in image_url:
             return False
         return True
 
-    async def update_spot_image(self, spot: dict, main_location: str, used_image_urls: set):
-        # 이미지 검색 쿼리에서는 기존 "-인물" 옵션 제거, 장소 이름 그대로 검색
+    async def update_spot_image(
+        self, spot: dict, main_location: str, used_image_urls: set
+    ):
         queries = [
             f"{main_location} {spot['kor_name']} 사진",
             f"{spot['kor_name']} 대표 사진",
         ]
         for query in queries:
             image_url = await self.get_tourist_info_tool._arun(query)
-            if image_url and await self.filter_image(image_url) and image_url not in used_image_urls:
+            if (
+                image_url
+                and await self.filter_image(image_url)
+                and image_url not in used_image_urls
+            ):
                 try:
                     async with aiohttp.ClientSession() as session:
-                        async with session.head(image_url, timeout=aiohttp.ClientTimeout(total=5)) as resp:
+                        async with session.head(
+                            image_url, timeout=aiohttp.ClientTimeout(total=5)
+                        ) as resp:
                             if resp.status == 200:
                                 spot["image_url"] = image_url
                                 used_image_urls.add(image_url)
-                                logger.info(f"Updated image for {spot['kor_name']}: {image_url}")
+                                logger.info(
+                                    f"Updated image for {spot['kor_name']}: {image_url}"
+                                )
                                 return
                 except Exception as e:
                     logger.warning(f"Image URL {image_url} 접근 실패: {e}")
         spot["image_url"] = None
-        logger.warning(f"Failed to update image for {spot['kor_name']}, setting to None.")
+        logger.warning(
+            f"Failed to update image for {spot['kor_name']}, setting to None."
+        )
 
-    async def fetch_additional_spots(self, main_location: str, seen_spots: set, required_count: int, exclusion_list: List[str]) -> List[dict]:
+    async def update_spot_coordinates(self, spot: dict, main_location: str):
+        """관광지의 주소를 기반으로 위도/경도 정보를 업데이트합니다."""
+        try:
+            address = spot.get("address")
+            if not address:
+                address = f"{main_location} {spot['kor_name']}"
+
+            coords = await self.kakao_tool.get_coordinates(address)
+            spot["latitude"] = coords["latitude"]
+            spot["longitude"] = coords["longitude"]
+
+            if spot["latitude"] == 0 and spot["longitude"] == 0:
+
+                coords = await self.kakao_tool.get_coordinates(
+                    f"{main_location} {spot['kor_name']}"
+                )
+                spot["latitude"] = coords["latitude"]
+                spot["longitude"] = coords["longitude"]
+
+            logger.info(f"Updated coordinates for {spot['kor_name']}: {coords}")
+        except Exception as e:
+            logger.error(f"Failed to get coordinates for {spot['kor_name']}: {e}")
+            spot["latitude"] = 0
+            spot["longitude"] = 0
+
+    async def fetch_additional_spots(
+        self,
+        main_location: str,
+        seen_spots: set,
+        required_count: int,
+        exclusion_list: List[str],
+    ) -> List[dict]:
         query = f"{main_location} 관광지 추천"
         search_result = await self.get_tourist_list_tool._arun(query)
         additional_spots = []
@@ -267,7 +319,6 @@ class TouristAgentService:
                 for i in range(0, len(lines), 3):
                     if i + 2 < len(lines) and "Title:" in lines[i]:
                         title = lines[i].split("Title:")[1].split("Link:")[0].strip()
-                        # 만약 title이 기존 추천 목록에 있다면 건너뜁니다.
                         if title in exclusion_list:
                             continue
                         key = (title, f"{main_location} {title}")
@@ -284,7 +335,10 @@ class TouristAgentService:
                                 "business_status": True,
                                 "business_hours": "09:00 - 18:00",
                             }
-                            await self.update_spot_image(spot, main_location, used_image_urls)
+                            await self.update_spot_image(
+                                spot, main_location, used_image_urls
+                            )
+                            spot["spot_category"] = 1
                             additional_spots.append(spot)
                             seen_spots.add(key)
                             if len(additional_spots) >= required_count:
@@ -294,18 +348,32 @@ class TouristAgentService:
         return additional_spots
 
     @time_check
-    async def create_tourist_plan(self, input_data: dict, redis_client: Redis = None, session: Optional[AsyncSession] = None, prompt: Optional[str] = "") -> dict:
+    async def create_tourist_plan(
+        self,
+        input_data: dict,
+        redis_client: Redis = None,
+        session: Optional[AsyncSession] = None,
+        prompt: Optional[str] = "",
+    ) -> dict:
         if input_data is None:
             raise ValueError("[TouristAgent] 에러 - input_data이 없습니다.")
         logger.info("Starting create_tourist_plan with input_data: %s", input_data)
-        
-        # 템플릿 변수 "coordinates" 추가 (실제 결과에 맞게 수정 가능)
-        if "coordinates" not in input_data:
-            input_data["coordinates"] = "37.3942° N, 126.9255° E"
-        
+
+        if "coordinates" not in input_data or not input_data["coordinates"]:
+            main_location = input_data.get("main_location")
+            if main_location:
+                coords = await self.kakao_tool.get_coordinates(main_location)
+                input_data["coordinates"] = (
+                    f"{coords['latitude']}° N, {coords['longitude']}° E"
+                )
+            else:
+                input_data["coordinates"] = "37.3942° N, 126.9255° E"
+
         input_data["concepts"] = ", ".join(input_data.get("concepts", []))
         input_data["prompt"] = input_data.get("prompt", "") or prompt
-        days = calculate_trip_days(input_data.get("start_date", ""), input_data.get("end_date", ""))
+        days = calculate_trip_days(
+            input_data.get("start_date", ""), input_data.get("end_date", "")
+        )
         input_data["days"] = days
         input_data["n"] = days * 3
 
@@ -316,14 +384,18 @@ class TouristAgentService:
         try:
             if "member_id" not in input_data or not input_data["member_id"]:
                 if session is None:
-                    raise ValueError("[TouristAgent] 에러 - member_id가 필요하며, 세션이 제공되지 않았습니다.")
+                    raise ValueError(
+                        "[TouristAgent] 에러 - member_id가 필요하며, 세션이 제공되지 않았습니다."
+                    )
                 email = input_data.get("email")
                 if not email:
                     raise ValueError("[TouristAgent] 에러 - email이 필요합니다.")
                 provider = input_data.get("provider")
                 member_id = await get_memberId_by_email(email, session, provider)
                 if not member_id:
-                    raise ValueError("[TouristAgent] 에러 - 인증된 사용자를 찾을 수 없습니다.")
+                    raise ValueError(
+                        "[TouristAgent] 에러 - 인증된 사용자를 찾을 수 없습니다."
+                    )
                 input_data["member_id"] = member_id
             member_id = input_data["member_id"]
             main_location = input_data.get("main_location")
@@ -333,42 +405,62 @@ class TouristAgentService:
                 logger.error("self.agents is not defined, reinitializing")
                 self.initialize()
             self.tasks = self._create_tasks(input_data, prompt)
-            logger.info("[TouristAgent] Tasks updated with main_location: %s", main_location)
+            logger.info(
+                "[TouristAgent] Tasks updated with main_location: %s", main_location
+            )
             self.tasks["researcher_task"].context = [self.tasks["collector_task"]]
-            self.tasks["researcher_detail_task"].context = [self.tasks["researcher_task"]]
+            self.tasks["researcher_detail_task"].context = [
+                self.tasks["researcher_task"]
+            ]
             self.tasks["reviewer_task"].context = [self.tasks["researcher_detail_task"]]
             self.tasks["decider_task"].context = [self.tasks["reviewer_task"]]
 
-            cached_tourist_lists = await spot_redis_service.get_spots(member_id, SpotCategory.SITE, main_location)
-            # Redis에 저장된 관광지 이름 목록 (중복 제거용)
-            exclusion_list = [spot.get("kor_name") for spot in cached_tourist_lists if spot.get("kor_name")]
+            cached_tourist_lists = await spot_redis_service.get_spots(
+                member_id, SpotCategory.SITE, main_location
+            )
+            exclusion_list = [
+                spot.get("kor_name")
+                for spot in cached_tourist_lists
+                if spot.get("kor_name")
+            ]
             input_data["existing_spot_names"] = exclusion_list
 
             used_image_urls = set()
             seen_spots = set()
             existing_spots_from_db = []
             if input_data.get("plan_id"):
-                plan_spots = await get_member_plan_spots(input_data["plan_id"], member_id, session)
+                plan_spots = await get_member_plan_spots(
+                    input_data["plan_id"], member_id, session
+                )
                 if plan_spots and "detail" in plan_spots:
-                    existing_spots_from_db = [{
-                        "kor_name": item["spot"].kor_name,
-                        "eng_name": item["spot"].eng_name,
-                        "address": item["spot"].address,
-                        "url": item["spot"].url,
-                        "image_url": item["spot"].image_url,
-                        "map_url": item["spot"].map_url,
-                        "spot_category": item["spot"].spot_category,
-                        "phone_number": item["spot"].phone_number,
-                        "business_status": item["spot"].business_status,
-                        "business_hours": item["spot"].business_hours,
-                    } for item in plan_spots["detail"]]
-                    input_data["existing_spot_names"] = [spot["kor_name"] for spot in existing_spots_from_db]
+                    existing_spots_from_db = [
+                        {
+                            "kor_name": item["spot"].kor_name,
+                            "eng_name": item["spot"].eng_name,
+                            "address": item["spot"].address,
+                            "url": item["spot"].url,
+                            "image_url": item["spot"].image_url,
+                            "map_url": item["spot"].map_url,
+                            "spot_category": 1,
+                            "phone_number": item["spot"].phone_number,
+                            "business_status": item["spot"].business_status,
+                            "business_hours": item["spot"].business_hours,
+                        }
+                        for item in plan_spots["detail"]
+                    ]
+                    input_data["existing_spot_names"] = [
+                        spot["kor_name"] for spot in existing_spots_from_db
+                    ]
                     for spot in existing_spots_from_db:
                         seen_spots.add((spot["kor_name"], spot["address"]))
 
             if not input_data.get("plan_id"):
-                logger.info("[TouristAgent] Cached tourist lists: %s", cached_tourist_lists)
-                cached_unique = [spot for spot in cached_tourist_lists if spot.get("kor_name")]
+                logger.info(
+                    "[TouristAgent] Cached tourist lists: %s", cached_tourist_lists
+                )
+                cached_unique = [
+                    spot for spot in cached_tourist_lists if spot.get("kor_name")
+                ]
 
                 if len(cached_unique) < days * 3:
                     crew = Crew(
@@ -378,16 +470,27 @@ class TouristAgentService:
                         verbose=True,
                     )
                     result = await crew.kickoff_async(inputs=input_data)
-                    logger.info("[TouristAgent] Crew execution completed with result: %s", result)
-                    if result is None or not hasattr(result, "tasks_output") or not result.tasks_output:
-                        raise ValueError("[TouristAgent] 에러 - Crew 실행 결과가 비어 있음")
+                    logger.info(
+                        "[TouristAgent] Crew execution completed with result: %s",
+                        result,
+                    )
+                    if (
+                        result is None
+                        or not hasattr(result, "tasks_output")
+                        or not result.tasks_output
+                    ):
+                        raise ValueError(
+                            "[TouristAgent] 에러 - Crew 실행 결과가 비어 있음"
+                        )
                     final_output = result.tasks_output[-1].raw
                     try:
                         final_result = json.loads(final_output)
                         if isinstance(final_result, dict) and "spots" in final_result:
                             final_result = final_result["spots"]
                         if not isinstance(final_result, list):
-                            raise ValueError("[TouristAgent] 에러 - final_result가 리스트가 아님")
+                            raise ValueError(
+                                "[TouristAgent] 에러 - final_result가 리스트가 아님"
+                            )
                     except json.JSONDecodeError:
                         logger.warning("final_output 파싱 실패, 기본 데이터 사용")
                         final_result = cached_unique
@@ -398,62 +501,89 @@ class TouristAgentService:
                         verbose=True,
                     )
                     result = await draft_crew.kickoff_async(inputs=input_data)
-                    if result is None or not hasattr(result, "tasks_output") or not result.tasks_output:
-                        raise ValueError("[TouristAgent] 에러 - Draft Crew 실행 결과가 비어 있음")
+                    if (
+                        result is None
+                        or not hasattr(result, "tasks_output")
+                        or not result.tasks_output
+                    ):
+                        raise ValueError(
+                            "[TouristAgent] 에러 - Draft Crew 실행 결과가 비어 있음"
+                        )
                     final_output = result.tasks_output[-1].raw
                     try:
                         final_result = json.loads(final_output)
                         if isinstance(final_result, dict) and "spots" in final_result:
                             final_result = final_result["spots"]
                         if not isinstance(final_result, list):
-                            raise ValueError("[TouristAgent] 에러 - final_result가 리스트가 아님")
+                            raise ValueError(
+                                "[TouristAgent] 에러 - final_result가 리스트가 아님"
+                            )
                     except json.JSONDecodeError:
                         logger.warning("final_output 파싱 실패, 기본 데이터 사용")
                         final_result = cached_unique
 
-                # 최종 결과에서 Redis에 이미 저장된 관광지는 제외
-                final_result = [spot for spot in final_result if spot.get("kor_name") not in exclusion_list]
+                final_result = [
+                    spot
+                    for spot in final_result
+                    if spot.get("kor_name") not in exclusion_list
+                ]
 
-                # reviewer_task(웹 검색 결과) 보정: 웹 검색 결과에 따라 image_url 및 description 업데이트
                 if hasattr(result, "tasks_output"):
                     for task_output in result.tasks_output:
                         if "관광지 웹 검색가" in str(task_output):
                             try:
                                 web_output = json.loads(task_output.raw)
                                 for spot in final_result:
-                                    full_place_id = f"{main_location} {spot['kor_name']}"
+                                    full_place_id = (
+                                        f"{main_location} {spot['kor_name']}"
+                                    )
                                     for web_spot in web_output:
                                         if full_place_id == web_spot.get("placeId"):
-                                            spot["image_url"] = web_spot.get("image_url", spot["image_url"])
-                                            spot["description"] = web_spot.get("description", spot.get("description", ""))
+                                            spot["image_url"] = web_spot.get(
+                                                "image_url", spot["image_url"]
+                                            )
+                                            spot["description"] = web_spot.get(
+                                                "description",
+                                                spot.get("description", ""),
+                                            )
                             except json.JSONDecodeError:
                                 logger.warning("웹 검색 결과 파싱 실패, 데이터 없음")
-                
+
                 unique_final_result = []
                 for spot in final_result:
                     key = (spot.get("kor_name"), spot.get("address"))
                     if key not in seen_spots:
                         spot["placeId"] = f"{main_location} {spot['kor_name']}"
-                        await self.update_spot_image(spot, main_location, used_image_urls)
-                        spot["spot_category"] = spot.get("spot_category", 1)
+                        await self.update_spot_image(
+                            spot, main_location, used_image_urls
+                        )
+                        await self.update_spot_coordinates(spot, main_location)
+                        spot["spot_category"] = 1
                         unique_final_result.append(spot)
                         seen_spots.add(key)
-                
+
                 merged_list = unique_final_result
                 final_merged = []
                 final_seen = set()
                 for spot in merged_list:
                     key = (spot.get("kor_name"), spot.get("address"))
                     if key not in final_seen and len(final_merged) < input_data["n"]:
+                        spot["spot_category"] = 1
                         final_merged.append(spot)
                         final_seen.add(key)
-                
+
                 if len(final_merged) < input_data["n"]:
                     required_count = input_data["n"] - len(final_merged)
-                    logger.warning(f"Only {len(final_merged)} spots found, fetching {required_count} additional spots.")
-                    additional_spots = await self.fetch_additional_spots(main_location, final_seen, required_count, exclusion_list)
+                    logger.warning(
+                        f"Only {len(final_merged)} spots found, fetching {required_count} additional spots."
+                    )
+                    additional_spots = await self.fetch_additional_spots(
+                        main_location, final_seen, required_count, exclusion_list
+                    )
+                    for spot in additional_spots:
+                        spot["spot_category"] = 1
                     final_merged.extend(additional_spots)
-                
+
                 if redis_client and member_id:
                     redis_key = str(member_id)
                     processed_result = {
@@ -466,16 +596,27 @@ class TouristAgentService:
                         },
                         "spots": final_merged,
                     }
-                    await redis_client.set(redis_key, json.dumps(processed_result), ex=86400)
+                    await redis_client.set(
+                        redis_key, json.dumps(processed_result), ex=86400
+                    )
                     logger.info("[DEBUG] Redis에 key='%s'로 저장 완료.", redis_key)
-                
-                final_result_with_time = self._assign_spot_times(final_merged, days, input_data)
+
+                for spot in final_merged:
+                    spot["spot_category"] = 1
+                final_result_with_time = self._assign_spot_times(
+                    final_merged, days, input_data
+                )
+
+                for spot in final_result_with_time:
+                    spot["spot_category"] = 1
                 return final_result_with_time
-            
+
             else:
                 current_plan_id = input_data.get("plan_id")
                 if "main_location" not in input_data or not input_data["main_location"]:
-                    raise ValueError("[TouristAgent] 에러 - main_location이 필요합니다.")
+                    raise ValueError(
+                        "[TouristAgent] 에러 - main_location이 필요합니다."
+                    )
                 main_location = input_data["main_location"]
                 crew = Crew(
                     agents=list(self.agents.values()),
@@ -484,7 +625,11 @@ class TouristAgentService:
                     verbose=True,
                 )
                 result = await crew.kickoff_async(inputs=input_data)
-                if result is None or not hasattr(result, "tasks_output") or not result.tasks_output:
+                if (
+                    result is None
+                    or not hasattr(result, "tasks_output")
+                    or not result.tasks_output
+                ):
                     raise ValueError("[TouristAgent] 에러 - Crew 실행 결과가 비어 있음")
                 final_output = result.tasks_output[-1].raw
                 try:
@@ -492,36 +637,55 @@ class TouristAgentService:
                     if isinstance(final_result, dict) and "spots" in final_result:
                         final_result = final_result["spots"]
                     if not isinstance(final_result, list):
-                        raise ValueError("[TouristAgent] 에러 - final_result가 리스트가 아님")
+                        raise ValueError(
+                            "[TouristAgent] 에러 - final_result가 리스트가 아님"
+                        )
                 except json.JSONDecodeError:
                     logger.warning("final_output 파싱 실패, DB 데이터 사용")
                     final_result = existing_spots_from_db
-                
+
                 if hasattr(result, "tasks_output"):
                     for task_output in result.tasks_output:
                         if "관광지 웹 검색가" in str(task_output):
                             try:
                                 web_output = json.loads(task_output.raw)
                                 for spot in final_result:
-                                    full_place_id = f"{main_location} {spot['kor_name']}"
+                                    full_place_id = (
+                                        f"{main_location} {spot['kor_name']}"
+                                    )
                                     for web_spot in web_output:
                                         if full_place_id == web_spot.get("placeId"):
-                                            spot["image_url"] = web_spot.get("image_url", spot["image_url"])
-                                            spot["description"] = web_spot.get("description", spot.get("description", ""))
+                                            spot["image_url"] = web_spot.get(
+                                                "image_url", spot["image_url"]
+                                            )
+                                            spot["description"] = web_spot.get(
+                                                "description",
+                                                spot.get("description", ""),
+                                            )
                             except json.JSONDecodeError:
                                 logger.warning("웹 검색 결과 파싱 실패, 데이터 없음")
-                
+
                 unique_final_result = []
                 for spot in final_result:
                     key = (spot.get("kor_name"), spot.get("address"))
                     if key not in seen_spots:
                         spot["placeId"] = f"{main_location} {spot['kor_name']}"
-                        await self.update_spot_image(spot, main_location, used_image_urls)
-                        spot["spot_category"] = spot.get("spot_category", 1)
+                        await self.update_spot_image(
+                            spot, main_location, used_image_urls
+                        )
+                        await self.update_spot_coordinates(spot, main_location)
+                        spot["spot_category"] = 1
                         unique_final_result.append(spot)
                         seen_spots.add(key)
-                
-                final_result_with_time = self._assign_spot_times(unique_final_result, days, input_data)
+
+                for spot in unique_final_result:
+                    spot["spot_category"] = 1
+                final_result_with_time = self._assign_spot_times(
+                    unique_final_result, days, input_data
+                )
+
+                for spot in final_result_with_time:
+                    spot["spot_category"] = 1
                 return final_result_with_time
 
         except Exception as e:
@@ -541,6 +705,7 @@ class TouristAgentService:
                 spot = spots[spot_index].copy()
                 spot["day"] = current_day
                 spot["order"] = time_slots.index(time_slot) + 1
+                spot["spot_category"] = 1
                 sorted_spots.append(spot)
                 spot_index += 1
             current_day += 1
@@ -548,6 +713,7 @@ class TouristAgentService:
             spot = spots[spot_index].copy()
             spot["day"] = days
             spot["order"] = len([s for s in sorted_spots if s["day"] == days]) + 1
+            spot["spot_category"] = 1
             sorted_spots.append(spot)
             spot_index += 1
         return sorted_spots

--- a/app/services/agents/tools/site_tool.py
+++ b/app/services/agents/tools/site_tool.py
@@ -17,8 +17,11 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 load_dotenv()
+
 AGENT_NAVER_CLIENT_ID = os.getenv("AGENT_NAVER_CLIENT_ID")
 AGENT_NAVER_CLIENT_SECRET = os.getenv("AGENT_NAVER_CLIENT_SECRET")
+KAKAO_API_KEY = os.getenv("KAKAO_API_KEY")
+
 
 def clean_query(query: str) -> str:
     clean_lines = []
@@ -31,11 +34,14 @@ def clean_query(query: str) -> str:
             clean_lines.append(line)
     return " ".join(clean_lines)
 
+
 async def check_url_openable_async(url: str) -> bool:
     if not url:
         return False
     try:
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=10)
+        ) as session:
             async with session.head(url, allow_redirects=True) as response:
                 logger.info(f"URL {url} status: {response.status}")
                 return 200 <= response.status < 400
@@ -44,10 +50,47 @@ async def check_url_openable_async(url: str) -> bool:
         return False
 
 
+class KakaoGeocodeTool:
+    def __init__(self):
+        self.api_key = KAKAO_API_KEY
+        self.base_url = "https://dapi.kakao.com/v2/local/search/address.json"
+
+    async def get_coordinates(self, address: str) -> dict:
+        headers = {"Authorization": f"KakaoAK {self.api_key}"}
+        params = {"query": address}
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                self.base_url, headers=headers, params=params
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    documents = data.get("documents", [])
+                    if documents:
+                        addr_info = documents[0].get("address", {})
+                        try:
+                            longitude = float(addr_info.get("x", 0))
+                            latitude = float(addr_info.get("y", 0))
+                        except (TypeError, ValueError):
+                            longitude, latitude = 0, 0
+                        return {"latitude": latitude, "longitude": longitude}
+                    else:
+                        logger.warning(
+                            "KakaoGeocodeTool: No address info found for: %s", address
+                        )
+                        return {"latitude": 0, "longitude": 0}
+                else:
+                    logger.error(
+                        "KakaoGeocodeTool: API error with status %s", response.status
+                    )
+                    return {"latitude": 0, "longitude": 0}
+
+
 class NaverBlogSearchTool(BaseTool):
     name: str = "NaverBlogSearchTool"
-    description: str = "Searches Naver blogs and extracts review text for tourist spots."
-    
+    description: str = (
+        "Searches Naver blogs and extracts review text for tourist spots."
+    )
+
     async def _fetch_query(self, client: httpx.AsyncClient, query: str) -> list:
         await asyncio.sleep(random.uniform(0.05, 0.2))
         url = "https://openapi.naver.com/v1/search/blog.json"
@@ -66,13 +109,12 @@ class NaverBlogSearchTool(BaseTool):
         except Exception as e:
             logger.error(f"[NaverBlogSearchTool] 검색 쿼리 {query} 에러: {str(e)}")
             return []
-    
+
     async def _fetch_blog_data(self, client: httpx.AsyncClient, url: str) -> str:
         await asyncio.sleep(random.uniform(0.05, 0.2))
-        url = url.replace('https://blog.naver.com', 'https://m.blog.naver.com')
+        url = url.replace("https://blog.naver.com", "https://m.blog.naver.com")
         headers = {
-            "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) "
-                          "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1",
+            "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1",
             "Referer": "https://m.blog.naver.com/",
         }
         try:
@@ -80,12 +122,12 @@ class NaverBlogSearchTool(BaseTool):
             resp.raise_for_status()
             soup = BeautifulSoup(resp.text, "html.parser")
             text = soup.get_text(separator=" ", strip=True)
-            reviews = text.split('.')[:3]
+            reviews = text.split(".")[:3]
             return ". ".join(reviews).strip()
         except Exception as e:
             logger.error(f"[NaverBlogSearchTool] 블로그 데이터 크롤링 에러: {str(e)}")
             return ""
-    
+
     async def _arun(self, query: str) -> str:
         cleaned_query = clean_query(query)
         async with httpx.AsyncClient() as client:
@@ -95,16 +137,17 @@ class NaverBlogSearchTool(BaseTool):
                 return blog_review
             else:
                 return ""
-    
+
     def _run(self, query: str) -> str:
         return asyncio.run(self._arun(query))
 
 
-# --- NaverTouristWebSearchTool ---
 class NaverTouristWebSearchTool(BaseTool):
     name: str = "NaverTouristWebSearchTool"
-    description: str = "Searches for tourist information using the Naver Web Search API."
-    
+    description: str = (
+        "Searches for tourist information using the Naver Web Search API."
+    )
+
     async def _arun(self, query: str) -> str:
         if not AGENT_NAVER_CLIENT_ID or not AGENT_NAVER_CLIENT_SECRET:
             return "[NaverTouristWebSearchTool] No Naver API credentials found."
@@ -130,40 +173,43 @@ class NaverTouristWebSearchTool(BaseTool):
                         title = re.sub(r"<.*?>", "", item.get("title", ""))
                         link = item.get("link", "")
                         description = item.get("description", "")
-                        results.append(f"Title: {title}\nLink: {link}\nDescription: {description}")
+                        results.append(
+                            f"Title: {title}\nLink: {link}\nDescription: {description}"
+                        )
                     return "\n".join(results)
         except Exception as e:
             logger.error(f"Tourist web search error: {e}")
             return ""
-    
+
     def _run(self, query: str) -> str:
         return asyncio.run(self._arun(query))
 
 
-# --- NaverTouristImageSearchTool ---
 class NaverTouristImageSearchTool(BaseTool):
     name: str = "NaverTouristImageSearchTool"
-    description: str = "Searches for representative images of tourist spots using the Naver Image Search API."
+    description: str = (
+        "Searches for representative images of tourist spots using the Naver Image Search API."
+    )
     used_urls: ClassVar[set] = set()
-    
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         logger.info("Initializing NaverTouristImageSearchTool")
-    
+
     def similarity(self, a: str, b: str) -> float:
         return difflib.SequenceMatcher(None, a, b).ratio()
-    
+
     async def _arun(self, query: Union[str, dict]) -> str:
         if isinstance(query, dict):
             query = query.get("description", "")
         if not query.strip():
             logger.warning("Empty query provided to NaverTouristImageSearchTool.")
             return "https://via.placeholder.com/300x200?text=No+Query"
-        
+
         if not AGENT_NAVER_CLIENT_ID or not AGENT_NAVER_CLIENT_SECRET:
             logger.error("Naver API credentials are missing.")
             return "[NaverTouristImageSearchTool] No Naver API credentials found."
-        
+
         url = "https://openapi.naver.com/v1/search/image"
         headers = {
             "X-Naver-Client-Id": AGENT_NAVER_CLIENT_ID,
@@ -174,10 +220,9 @@ class NaverTouristImageSearchTool(BaseTool):
         cleaned_query = clean_query(query)
         logger.info(f"[Tourist Image Search Query]: {cleaned_query}")
         params = {"query": cleaned_query, "display": 10, "sort": "sim", "filter": "all"}
-        
-        # 유사도 임계값을 낮춰서 검증 조건 완화 (또는 아예 제거할 수 있음)
+
         SIMILARITY_THRESHOLD = 0.05
-        
+
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get(url, headers=headers, params=params) as response:
@@ -186,9 +231,11 @@ class NaverTouristImageSearchTool(BaseTool):
                     logger.info(f"API Response: {data}")
                     items = data.get("items", [])
                     if not items:
-                        logger.warning(f"No image items found for query: {cleaned_query}")
+                        logger.warning(
+                            f"No image items found for query: {cleaned_query}"
+                        )
                         return "https://via.placeholder.com/300x200?text=No+Image"
-                    
+
                     for item in items:
                         img_url = item.get("link", "")
                         title = item.get("title", "").lower()
@@ -197,7 +244,9 @@ class NaverTouristImageSearchTool(BaseTool):
                             continue
                         sim = self.similarity(cleaned_query.lower(), title)
                         if sim < SIMILARITY_THRESHOLD:
-                            logger.info(f"Skipping image due to low similarity: {title} (similarity={sim:.2f})")
+                            logger.info(
+                                f"Skipping image due to low similarity: {title} (similarity={sim:.2f})"
+                            )
                             continue
                         logger.info(f"Checking image URL: {img_url}")
                         if await check_url_openable_async(img_url):
@@ -206,22 +255,25 @@ class NaverTouristImageSearchTool(BaseTool):
                             return img_url
                         else:
                             logger.warning(f"Image URL not accessible: {img_url}")
-                    
-                    logger.info("No accessible or unique image URLs found, returning placeholder.")
+
+                    logger.info(
+                        "No accessible or unique image URLs found, returning placeholder."
+                    )
                     return "https://via.placeholder.com/300x200?text=No+Image"
         except Exception as e:
             logger.error(f"Tourist image search error: {e}")
             return "https://via.placeholder.com/300x200?text=Error"
-    
+
     def _run(self, query: Union[str, dict]) -> str:
         return asyncio.run(self._arun(query))
 
 
-# --- NaverTouristReviewTool ---
 class NaverTouristReviewTool(BaseTool):
     name: str = "NaverTouristReviewTool"
-    description: str = "Crawls Naver reviews to extract tourist spot reviews and representative image."
-    
+    description: str = (
+        "Crawls Naver reviews to extract tourist spot reviews and representative image."
+    )
+
     async def _find_place_id(self, query: str) -> Optional[str]:
         if not AGENT_NAVER_CLIENT_ID or not AGENT_NAVER_CLIENT_SECRET:
             logger.error("Naver API credentials missing for place ID search.")
@@ -244,7 +296,9 @@ class NaverTouristReviewTool(BaseTool):
                         link = items[0].get("link", "")
                         place_id = re.search(r"place/(\d+)", link)
                         if place_id:
-                            logger.info(f"Found place ID {place_id.group(1)} for {query}")
+                            logger.info(
+                                f"Found place ID {place_id.group(1)} for {query}"
+                            )
                             return place_id.group(1)
                         logger.warning(f"No place ID found in link: {link}")
                         return None
@@ -253,12 +307,13 @@ class NaverTouristReviewTool(BaseTool):
         except Exception as e:
             logger.error(f"Place ID search error for {query}: {e}")
             return None
-    
-    async def _fetch_review_data(self, client: httpx.AsyncClient, place_id: str, original_query: str) -> Union[dict, str]:
+
+    async def _fetch_review_data(
+        self, client: httpx.AsyncClient, place_id: str, original_query: str
+    ) -> Union[dict, str]:
         url = f"https://m.place.naver.com/place/{place_id}/review/visitor?reviewSort=recent"
         headers = {
-            "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) "
-                          "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1",
+            "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1",
             "Referer": "https://m.place.naver.com/",
         }
         try:
@@ -268,16 +323,25 @@ class NaverTouristReviewTool(BaseTool):
             reviews = soup.find_all("div", class_="pui__vn15t2")
             if reviews:
                 thumbnail_tag = soup.find("a", class_="place_thumb")
-                thumbnail = thumbnail_tag.find("img").get("src") if thumbnail_tag else None
-                reviews_list = [emoji.replace_emoji(review.text, replace="") for review in reviews]
-                logger.info(f"Reviews fetched for place_id {place_id}: {reviews_list[:2]}")
+                thumbnail = (
+                    thumbnail_tag.find("img").get("src") if thumbnail_tag else None
+                )
+                reviews_list = [
+                    emoji.replace_emoji(review.text, replace="") for review in reviews
+                ]
+                logger.info(
+                    f"Reviews fetched for place_id {place_id}: {reviews_list[:2]}"
+                )
                 return {
                     "placeId": place_id,
-                    "image_url": thumbnail or "https://via.placeholder.com/300x200?text=No+Thumbnail",
+                    "image_url": thumbnail
+                    or "https://via.placeholder.com/300x200?text=No+Thumbnail",
                     "reviews": reviews_list,
                 }
             else:
-                logger.warning(f"No reviews found for place_id {place_id} via mobile, trying blog fallback.")
+                logger.warning(
+                    f"No reviews found for place_id {place_id} via mobile, trying blog fallback."
+                )
                 blog_tool = NaverBlogSearchTool()
                 blog_query = f"{original_query} 관광지 리뷰"
                 blog_review_text = await blog_tool._arun(blog_query)
@@ -285,7 +349,7 @@ class NaverTouristReviewTool(BaseTool):
                     return {
                         "placeId": place_id,
                         "image_url": "https://via.placeholder.com/300x200?text=No+Thumbnail",
-                        "reviews": blog_review_text.split('.')[:3],
+                        "reviews": blog_review_text.split(".")[:3],
                     }
                 else:
                     logger.warning(f"No blog results for fallback query: {blog_query}")
@@ -293,7 +357,7 @@ class NaverTouristReviewTool(BaseTool):
         except Exception as e:
             logger.error(f"Review fetch error for place_id {place_id}: {e}")
             return f"[NaverTouristReviewTool] Error: {str(e)}"
-    
+
     async def _arun(self, placeIds: List[str]) -> str:
         async with httpx.AsyncClient() as client:
             tasks = []
@@ -303,28 +367,41 @@ class NaverTouristReviewTool(BaseTool):
                     tasks.append(self._fetch_review_data(client, place_id, place_name))
                 else:
                     logger.warning(f"Skipping {place_name} due to no place ID found.")
-                    tasks.append(asyncio.sleep(0, result={"placeId": place_name, "image_url": None, "reviews": []}))
+                    tasks.append(
+                        asyncio.sleep(
+                            0,
+                            result={
+                                "placeId": place_name,
+                                "image_url": None,
+                                "reviews": [],
+                            },
+                        )
+                    )
             results = await asyncio.gather(*tasks)
         valid_results = [res for res in results if isinstance(res, dict)]
-        logger.info(f"Valid review results: {len(valid_results)} out of {len(placeIds)}")
+        logger.info(
+            f"Valid review results: {len(valid_results)} out of {len(placeIds)}"
+        )
         return json.dumps(valid_results, indent=4, ensure_ascii=False)
-    
+
     def _run(self, placeIds: List[str]) -> str:
         return asyncio.run(self._arun(placeIds))
 
 
-# --- NaverTouristBusinessInfoTool ---
 class NaverTouristBusinessInfoTool(BaseTool):
     name: str = "NaverTouristBusinessInfoTool"
-    description: str = "Crawls Naver to extract business info of tourist spots including website, operating hours, and category."
-    
-    async def _fetch_business_info(self, client: httpx.AsyncClient, placeId: str) -> Union[dict, str]:
+    description: str = (
+        "Crawls Naver to extract business info of tourist spots including website, operating hours, and category."
+    )
+
+    async def _fetch_business_info(
+        self, client: httpx.AsyncClient, placeId: str
+    ) -> Union[dict, str]:
         url = f"https://m.place.naver.com/place/{placeId}/home"
         headers = {
             "X-Naver-Client-Id": AGENT_NAVER_CLIENT_ID,
             "X-Naver-Client-Secret": AGENT_NAVER_CLIENT_SECRET,
-            "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) "
-                          "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1",
+            "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1",
             "Referer": "https://m.place.naver.com/",
         }
         try:
@@ -352,13 +429,13 @@ class NaverTouristBusinessInfoTool(BaseTool):
         except Exception as e:
             logger.error(f"Business info fetch error for {placeId}: {e}")
             return f"[NaverTouristBusinessInfoTool] Error: {str(e)}"
-    
+
     async def _arun(self, placeIds: List[str]) -> str:
         async with httpx.AsyncClient() as client:
             tasks = [self._fetch_business_info(client, placeId) for placeId in placeIds]
             results = await asyncio.gather(*tasks)
         valid_results = [res for res in results if isinstance(res, dict)]
         return json.dumps(valid_results, indent=4, ensure_ascii=False)
-    
+
     def _run(self, placeIds: List[str]) -> str:
         return asyncio.run(self._arun(placeIds))


### PR DESCRIPTION
spot_category 고정:
모든 관광지 항목에 대해 spot_category 값이 항상 1로 설정되도록 수정했습니다.
기존 데이터 및 LLM 응답에서 발생할 수 있는 값 불일치를 방지하여 데이터 일관성을 보장합니다.

위도/경도 업데이트:
각 관광지의 주소(또는 관광지 이름 포함 주소)를 기반으로 카카오 API를 활용하여 위도와 경도 정보를 가져오는 기능을 추가했습니다.
새로운 update_spot_coordinates 메서드를 통해 주소로 검색 후 실패 시 관광지 이름으로 재시도하여 좌표 정보를 업데이트합니다.